### PR TITLE
Add secret volume to prometheus pusher deployment

### DIFF
--- a/pkg/monitoring/deployment.go
+++ b/pkg/monitoring/deployment.go
@@ -5,8 +5,6 @@ package monitoring
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/golang/glog"
 	"github.com/verrazzano/verrazzano-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-operator/pkg/util"
@@ -132,12 +130,4 @@ func newVal(value int32) *int32 {
 func new64Val(value int64) *int64 {
 	var val = value
 	return &val
-}
-
-func getVerrazzanoName(verrazzanoUri string) string {
-	segs := strings.Split(verrazzanoUri, ".")
-	if len(segs) > 1 {
-		return segs[0]
-	}
-	return ""
 }


### PR DESCRIPTION
Add secret volume and volumeMount to prometheus pusher deployment so that the pusher pod can access the root certificate.  This fixes the problem where the pusher was getting x509: certificate signed by unknown authority.  Also set an ENV var with the cert path.

Tested prometheus pusher with xip.io.  Verified that prom pusher deployment contained the correct information to make the ca.crt available to the pod:

ENV:..
    - name: PROM_CERT
      value: /verrazzano/certs/ca.crt
..
    volumeMounts:
    - mountPath: /verrazzano/certs
      name: cert-vol
..
  volumes:
  - name: cert-vol
    secret:
      defaultMode: 420
      secretName: system-tls

Related PR https://github.com/verrazzano/verrazzano-monitoring-operator/pull/2