### PR TITLE
Reduce loglevel in prometheus pusher 

### DIFF
--- a/pkg/monitoring/deployment.go
+++ b/pkg/monitoring/deployment.go
@@ -75,7 +75,7 @@ func CreateDeployment(namespace string, bindingName string, labels map[string]st
 								},
 								{
 									Name:  "LOGLEVEL",
-									Value: "5",
+									Value: "4",
 								},
 								{
 									Name:  "SPLIT_SIZE",


### PR DESCRIPTION
Reduce loglevel in prometheus pusher  from debug to info to prevent the log file from filling up the disk.

Tested with OCI DNS using prometheus pusher image that i built.