### PR TITLE
upgrade verrazzano-monitoring-instance-eswait to v0.0.3 in helm chart

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -33,7 +33,7 @@ monitoringOperator:
   alertManagerImage: prom/alertmanager:v0.16.0
   esWaitTargetVersion: 7.6.1
   esImage: phx.ocir.io/odx-sre/sauron/elasticsearch-mirror:7.6.1-2
-  esWaitImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.2
+  esWaitImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.3
   esInitImage: oraclelinux:7
   kibanaImage: phx.ocir.io/odx-sre/sauron/kibana-mirror:7.6.1-2
   monitoringInstanceApiImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-api:v0.0.5


### PR DESCRIPTION
The previous version `phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.2` has 13 vulnerabilities reported by Clair, https://build.verrazzano.io/job/scan-image/52/artifact/scanning-report-1593210411.json.
The new version `phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.3` is clean, https://gitlab-odx.oracledx.com/verrazzano/verrazzano-monitoring-instance-eswait/-/jobs/1327015.