### PR TITLE
update image version for web and web-standalone with clear clair scan

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -78,8 +78,8 @@ config:
 verrazzanoConsole:
   name: verrazzano-console
   imageName: phx.ocir.io/stevengreenberginc/verrazzano/web
-  imageVersion: 1.0.19
+  imageVersion: 1.0.20
 
 verrazzanoConsoleWrapper:
   imageName: phx.ocir.io/stevengreenberginc/verrazzano/web-standalone
-  imageVersion: 1.0.21
+  imageVersion: 1.0.22


### PR DESCRIPTION
update image version for web and web-standalone with clear clair scan
- web - https://build.verrazzano.io/job/scan-image/64/
- web-standalone - https://build.verrazzano.io/job/scan-image/63/