### PR TITLE
VZ-690: Updating elasticsearch image.

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -33,7 +33,7 @@ monitoringOperator:
   prometheusGatewayImage: phx.ocir.io/stevengreenberginc/bfs/pushgateway:1.2.0-1
   alertManagerImage: prom/alertmanager:v0.16.0
   esWaitTargetVersion: 7.6.1
-  esImage: phx.ocir.io/odx-sre/sauron/elasticsearch-mirror:7.6.1-2
+  esImage: phx.ocir.io/stevengreenberginc/bfs/elasticsearch:7.6.1-80f8609-6
   esWaitImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.3
   esInitImage: oraclelinux:7
   kibanaImage: phx.ocir.io/stevengreenberginc/bfs/kibana:7.6.1-2


### PR DESCRIPTION
Adding phx.ocir.io/stevengreenberginc/bfs/elasticsearch:7.6.1-80f8609-6 esImage to verrazzano helm chart values.yaml.

Acceptance test passed: https://build.verrazzano.io/job/verrazzano/job/watsh_bfstest/8/