### PR TITLE
Update to latest VMO image

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -23,7 +23,7 @@ verrazzanoOperator:
 monitoringOperator:
   name: verrazzano-monitoring-operator
   imageName: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-operator
-  imageVersion: v0.0.16
+  imageVersion: v0.0.17
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1
@@ -34,7 +34,7 @@ monitoringOperator:
   alertManagerImage: prom/alertmanager:v0.16.0
   esWaitTargetVersion: 7.6.1
   esImage: phx.ocir.io/stevengreenberginc/bfs/elasticsearch:7.6.1-80f8609-6
-  esWaitImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.3
+  esWaitImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.17
   esInitImage: oraclelinux:7
   kibanaImage: phx.ocir.io/stevengreenberginc/bfs/kibana:7.6.1-2
   monitoringInstanceApiImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-api:v0.0.6


### PR DESCRIPTION
Update to updated VMO image - which had Sauron references renamed to VMO

Successful acceptance test suite run:
https://build.verrazzano.io/job/verrazzano/job/pb-updates-images/3/

Tested by modifying verrazzano project to override settings on deploy of helm chart
```
      --set verrazzanoOperator.imageName=phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-operator-jenkins \
      --set verrazzanoOperator.imageVersion=6a76a4a19f91e4fec2081c82f984c9a183d2fe2a \
      --set monitoringOperator.imageVersion=v0.0.17 \
      --set monitoringOperator.esImage=phx.ocir.io/stevengreenberginc/bfs/elasticsearch:7.6.1-80f8609-6 \
      --set monitoringOperator.esWaitImage=phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.17 \
```