### PR TITLE
VZ666 - Auth Policy changes for Prometheus

### DIFF
--- a/pkg/managed/istio.go
+++ b/pkg/managed/istio.go
@@ -574,7 +574,7 @@ func httpRoutes(namespace string, ingress *types.Ingress) []istiocrd.HttpRoute {
 		}
 		routes = append(routes, route)
 
-		// If the destination is a weblogic domain then add a match for the
+		// If the destination is a WebLogic domain then add a match for the
 		// WLS console
 		if len(destination.DomainName) != 0 {
 			routes = append(routes, istiocrd.HttpRoute{
@@ -665,8 +665,8 @@ func newServiceEntries(mbPair *types.ModelBindingPair, mc *types.ManagedCluster,
 
 // Construct the necessary Istio DestinationRule objects
 // Destination rules are created for each namespace named in the binding placement.  Each destination rule enables
-// MTLS for the entire namespace with one exception... MTLS is disabled for traffic on the Weblogic admin port to avoid
-// issues with Weblogic managed server communication with the admin server.
+// MTLS for the entire namespace with one exception... MTLS is disabled for traffic on the WebLogic admin port to avoid
+// issues with WebLogic managed server communication with the admin server.
 func newDestinationRules(mbPair *types.ModelBindingPair, mc *types.ManagedCluster, pods []*v1.Pod) ([]*v1alpha3.DestinationRule, error) {
 	var rules []*v1alpha3.DestinationRule
 	namespaceMap := make(map[string]struct{})
@@ -715,7 +715,7 @@ func newAuthorizationPolicies(mbPair *types.ModelBindingPair, mc *types.ManagedC
 	// map all of the model components to their namespaces
 	mapComponentNamespaces(mbPair, componentNameSpaces, namespaceSources)
 
-	// map the connected namespace sources for each Weblogic component
+	// map the connected namespace sources for each WebLogic component
 	for _, weblogic := range mbPair.Model.Spec.WeblogicDomains {
 		mapNamespaceSources(weblogic.Name, weblogic.Connections, componentNameSpaces, namespaceSources)
 	}


### PR DESCRIPTION
This work addresses a problem where some Prometheus metrics aren't available. This includes Helidon and WLS metrics. The primary reason for these metrics failures is related to the authorization policies. The system level Prometheus pod that scrapes the metrics from the sources isn't in the Istio mesh which results in the WLS and Helidon pods not being accessible by the Prometheus pod even though the istio-system ns is specified in the auth policies. Additionally, the WLS pods actually call themselves via a REST invocation.

To address the above issues the following changes were made in auth policy generation:
- add the IP addresses of all pods in the same namespace (handles WLS pods calling themselves)
- add the IP address of the system prometheus pod to all auth policies