### PR TITLE
Update the helm chart to use the latest tags of the docker images we build from source

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -41,7 +41,7 @@ monitoringOperator:
   kibanaImage: phx.ocir.io/stevengreenberginc/bfs/kibana:7.6.1-2270f8a-4
   monitoringInstanceApiImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-api:v0.0.6
   configReloaderImage: phx.ocir.io/stevengreenberginc/bfs/configmap-reload:0.3-3449794-32
-  nodeExporterImage: phx.ocir.io/stevengreenberginc/bfs/node-exporter:0.18.1-1
+  nodeExporterImage: phx.ocir.io/stevengreenberginc/bfs/node-exporter:0.18.1-25813b2-6
 
 clusterOperator:
   name: verrazzano-cluster-operator


### PR DESCRIPTION
Update the helm chart to use the latest tags of the docker images we build from source.

Successful acceptance test suite run: https://build.verrazzano.io/job/verrazzano/job/pb-bfs-update-helm/8

I tested by modifying the verrazzano install and adding the following commands to the helm deploy of verrazzano:
```
      --set monitoringOperator.esImage=phx.ocir.io/stevengreenberginc/bfs/elasticsearch:7.6.1-6e8328f-9 \
      --set monitoringOperator.kibanaImage=phx.ocir.io/stevengreenberginc/bfs/kibana:7.6.1-2270f8a-4 \
      --set verrazzanoOperator.imageName=phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-operator-jenkins \
      --set verrazzanoOperator.imageVersion=6d51fa9ea317dc33ebfaf5d76a879d8177f8df12 \
      --set verrazzanoOperator.prometheusPusherImage=phx.ocir.io/stevengreenberginc/bfs/prometheus-pusher:1.0.1-abedd4b-18 \
      --set monitoringOperator.prometheusGatewayImage=phx.ocir.io/stevengreenberginc/bfs/pushgateway:1.2.0-cf661e0-9 \
      --set verrazzanoOperator.filebeatImage=phx.ocir.io/stevengreenberginc/bfs/filebeat:6.8.3-c8d475a-5 \
      --set verrazzanoOperator.journalbeatImage=phx.ocir.io/stevengreenberginc/bfs/journalbeat:6.8.3-c8d475a-5 \
      --set verrazzanoOperator.nodeExporterImage=phx.ocir.io/stevengreenberginc/bfs/node-exporter:0.18.1-25813b2-6 \
      --set monitoringOperator.nodeExporterImage=phx.ocir.io/stevengreenberginc/bfs/node-exporter:0.18.1-25813b2-6 \
      --set monitoringOperator.configReloaderImage=phx.ocir.io/stevengreenberginc/bfs/configmap-reload:0.3-3449794-32 \
      --set verrazzanoOperator.fluentdImage=phx.ocir.io/stevengreenberginc/bfs/fluentd-kubernetes-daemonset:v1.10.4-6ce326d-16 \
```