### PR TITLE
Use configmap reloader image built from new oracle linux

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,7 +40,7 @@ monitoringOperator:
   esInitImage: oraclelinux:7
   kibanaImage: docker.elastic.co/kibana/kibana-oss:7.6.1
   monitoringInstanceApiImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-api:v0.0.6
-  configReloaderImage: phx.ocir.io/stevengreenberginc/bfs/configmap-reload:0.3-3449794-32
+  configReloaderImage: phx.ocir.io/stevengreenberginc/bfs/configmap-reload:0.3-81d6423-33
   nodeExporterImage: phx.ocir.io/stevengreenberginc/bfs/node-exporter:0.18.1-25813b2-6
 
 clusterOperator:


### PR DESCRIPTION
Use configmap reloader image built from new oracle linux

operator test: https://build.verrazzano.io/job/verrazzano-operator/job/pmackin-confimap-image/
Full acceptance test using this image built with the new oracle linux: https://build.verrazzano.io/job/verrazzano/job/pmackin-linux-image-1/6/

PR for the confimap reloader new image https://github.com/verrazzano/configmap-reload/pull/5 - you can see the image tag there