### PR TITLE
Do not encode url in db binding override config map

### DIFF
--- a/pkg/controller/model_binding_pair.go
+++ b/pkg/controller/model_binding_pair.go
@@ -6,7 +6,6 @@ package controller
 import (
 	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/url"
 	"strings"
 	"sync"
 
@@ -131,9 +130,8 @@ func buildModelBindingPair(mbPair *types.ModelBindingPair) *types.ModelBindingPa
 							// If this domain has a database connection that targets this database binding...
 							if len(datasourceName) > 0 {
 								// Create config map data for the database binding on this domain
-								escapedUrl := url.QueryEscape(databaseBinding.Url)
 								data[fmt.Sprintf("jdbc-%s.xml", strings.Replace(datasourceName, "/", "2f", -1))] =
-									createDatasourceConfigMap(databaseBinding.Credentials, escapedUrl, datasourceName)
+									createDatasourceConfigMap(databaseBinding.Credentials, databaseBinding.Url, datasourceName)
 								configOverrideSecrets = append(configOverrideSecrets, databaseBinding.Credentials)
 							}
 						}

--- a/pkg/controller/model_binding_pair_test.go
+++ b/pkg/controller/model_binding_pair_test.go
@@ -401,7 +401,7 @@ func validateDatabaseBindings(t *testing.T, mbp *types.ModelBindingPair) {
                   xmlns:s="http://xmlns.oracle.com/weblogic/situational-config">
   <name>%s</name>
   <jdbc-driver-params>
-    <url f:combine-mode="replace">jdbc%%3Amysql%%3A%%2F%%2Fmysql.default.svc.cluster.local%%3A3306%%2F%s</url>
+    <url f:combine-mode="replace">jdbc:mysql://mysql.default.svc.cluster.local:3306/%s</url>
     <properties>
        <property>
           <name>user</name>


### PR DESCRIPTION
Currently the database binding URL is encoded prior to adding it to the override config map.
```
escapedUrl := url.QueryEscape(databaseBinding.Url)
```
It should not be encoded.