### PR TITLE
upgrade console to 0.1.1 which uses newer oraclelinux base

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -80,8 +80,8 @@ config:
 verrazzanoConsole:
   name: verrazzano-console
   imageName: phx.ocir.io/stevengreenberginc/verrazzano/console-plugin
-  imageVersion: 0.1.0
+  imageVersion: 0.1.1
 
 verrazzanoConsoleWrapper:
   imageName: phx.ocir.io/stevengreenberginc/verrazzano/console
-  imageVersion: 0.1.0
+  imageVersion: 0.1.1


### PR DESCRIPTION
The Verrazzano branch to use these images is https://github.com/verrazzano/verrazzano/commit/da5e8c4bbf64548c53b5181e9dfc261409051659.
The acceptance test running here:  https://build.verrazzano.io/job/verrazzano/job/gz%252Fnewconsole/