### PR TITLE
Ignore the PR

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,42 +11,42 @@ verrazzanoOperator:
   imageName: phx.ocir.io/stevengreenberginc/verrazzano/OPERATOR_IMAGE_NAME
   imageVersion: OPERATOR_VERSION
   sslVerify: true
-  cohMicroImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-coh-cluster-operator:08a24582b5920a2fc95bc9a9e19b9a6659995e28
-  helidonMicroImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-helidon-app-operator:v0.0.7
-  wlsMicroImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-wko-operator:v0.0.8
+  cohMicroImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-coh-cluster-operator:v0.0.8
+  helidonMicroImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-helidon-app-operator:v0.0.6
+  wlsMicroImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-wko-operator:v0.0.6
   prometheusPusherImage: phx.ocir.io/stevengreenberginc/bfs/prometheus-pusher:1.0.1-ff71638-19
   nodeExporterImage: phx.ocir.io/stevengreenberginc/bfs/node-exporter:0.18.1-0f43627-7
   filebeatImage: phx.ocir.io/stevengreenberginc/bfs/filebeat:6.8.3-58a0ddf-6
   journalbeatImage: phx.ocir.io/stevengreenberginc/bfs/journalbeat:6.8.3-58a0ddf-6
   weblogicOperatorImage: oracle/weblogic-kubernetes-operator:2.6.0
-  fluentdImage: phx.ocir.io/stevengreenberginc/bfs/fluentd-kubernetes-daemonset:v1.10.4-6ce326d-17
+  fluentdImage: phx.ocir.io/stevengreenberginc/bfs/fluentd-kubernetes-daemonset:v1.10.4-6ce326d-16
   apiServerRealm: verrazzano-system
 
 monitoringOperator:
   name: verrazzano-monitoring-operator
   imageName: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-operator
-  imageVersion: v0.0.18
+  imageVersion: v0.0.17
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1
   grafanaImage: container-registry.oracle.com/olcne/grafana:v6.4.4
   prometheusImage: container-registry.oracle.com/olcne/prometheus:v2.13.1
-  prometheusInitImage: container-registry.oracle.com/os/oraclelinux:7-slim@sha256:9b86d1332a883ee8f68dd44ba42133de518b2e0ec1cc70257e59fb4da86b1ad3
+  prometheusInitImage: container-registry.oracle.com/os/oraclelinux:7-slim
   prometheusGatewayImage: phx.ocir.io/stevengreenberginc/bfs/pushgateway:1.2.0-6893444-10
   alertManagerImage: prom/alertmanager:v0.16.0
   esWaitTargetVersion: 7.6.1
   esImage: docker.elastic.co/elasticsearch/elasticsearch-oss:7.6.1
-  esWaitImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.18
-  esInitImage: container-registry.oracle.com/os/oraclelinux:7.8@sha256:46fc083cf0250ed5260fa6fe822d7d4c139ca1f7fc38e4a17ba662464bd1df4a
+  esWaitImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.17
+  esInitImage: oraclelinux:7
   kibanaImage: docker.elastic.co/kibana/kibana-oss:7.6.1
-  monitoringInstanceApiImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-api:v0.0.7
-  configReloaderImage: container-registry.oracle.com/verrazzano/configmap-reload:0.3-81d6423-33
+  monitoringInstanceApiImage: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-monitoring-instance-api:v0.0.6
+  configReloaderImage: phx.ocir.io/stevengreenberginc/bfs/configmap-reload:0.3-81d6423-33
   nodeExporterImage: phx.ocir.io/stevengreenberginc/bfs/node-exporter:0.18.1-0f43627-7
 
 clusterOperator:
   name: verrazzano-cluster-operator
   imageName: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-cluster-operator
-  imageVersion: 5b39d0e03d41b4f7739bc2429a1dd3d4d1aeea85
+  imageVersion: v0.0.7
   rancherURL:
   rancherUserName:
   rancherPassword:
@@ -56,7 +56,7 @@ verrazzanoAdmissionController:
   name: verrazzano-validation
   controllerName: verrazzano-admission-controller
   imageName: phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-admission-controller
-  imageVersion: e43e15c8eac1dbc48e0236d6c8ec1bd2a55bb248
+  imageVersion: v0.0.11
   caBundle:
 
 # OCI-related values


### PR DESCRIPTION
Use new images built from newer oracle linux images:

New images are:
phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-admission-controller:v0.0.11

phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-cluster-operator:v0.0.7

phx.ocir.io/stevengreenberginc/verrazzano/verrazzano-coh-cluster-operator:v0.0.8

phx.ocir.io/stevengreenberginc/bfs/fluentd-kubernetes-daemonset:v1.10.4-6ce326d-17

NOTE: fluentd-kubernetes-daemonset is built with the following fluentd-docker-image:
phx.ocir.io/stevengreenberginc/bfs/fluentd:v1.10.4-a2367f0-11
see https://build.verrazzano.io/view/oracle-build-from-source/job/fluentd-kubernetes-daemonset/job/oracle-build-from-source/17/parameters/

Acceptance test run previously: 
Acceptance Test: https://build.verrazzano.io/job/verrazzano/job/pmackin-images-4-fluent-etc/2/
