### PR TITLE
update console images to 0.1.2

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -80,8 +80,8 @@ config:
 verrazzanoConsole:
   name: verrazzano-console
   imageName: phx.ocir.io/stevengreenberginc/verrazzano/console-plugin
-  imageVersion: 0.1.1
+  imageVersion: 0.1.2
 
 verrazzanoConsoleWrapper:
   imageName: phx.ocir.io/stevengreenberginc/verrazzano/console
-  imageVersion: 0.1.1
+  imageVersion: 0.1.2


### PR DESCRIPTION
update console images to 0.1.2 which contain the licenses
Test Run - https://build.verrazzano.io/job/verrazzano/job/update-console-images-012/