### PR TITLE
VZ-960 - Limit vmi domain name length to 64 characters

### DIFF
--- a/chart/templates/04-verrazzano-admission-controller.yaml
+++ b/chart/templates/04-verrazzano-admission-controller.yaml
@@ -81,6 +81,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --v=4
+            - --verrazzanoUri={{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/certs


### PR DESCRIPTION
If ingress addresses are too long there is the potential to break certificate generation. Specifically the CN for the cert cannot exceed 64 chars. See https://docs.digicert.com/manage-certificates/public-certificates-data-entries-that/#64character-maximum-limit-violation.

Check that `*.vmi.<binding_name>.<env_name>.<dns_zone_name>` (e.g. `*.vmi.hello-world-binding.abcde202008051007.abcde.v8o.oracledx.com`) will not exceed 64 characters.

Need to pass `<env_name>.<dns_zone_name>` into the admission-controller to be combined with the binding name so that the length of the VMI domain name can be determined. Anything longer than 64 characters will cause the binding validation to fail.