### PR TITLE
VZ-1104: Remove helm chart from verrazzano-operator repo - push-tag fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,7 @@ pipeline {
             steps {
                 sh """
                     cd ${GO_REPO_PATH}/verrazzano-operator
-                    make push-tag DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME} DOCKER_PUBLISH_IMAGE_NAME=${env.DOCKER_PUBLISH_IMAGE_NAME}
+                    make push-tag DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME} DOCKER_PUBLISH_IMAGE_NAME=${DOCKER_PUBLISH_IMAGE_NAME}
                 """
             }
         }


### PR DESCRIPTION
Fix the push-tag call in the jenkinsfile to use the correct image name on the master branch.