### PR TITLE
Update verrazzano-system clusterrole to fix weblogic-operator permission error

### DIFF
--- a/pkg/managed/clusterroles.go
+++ b/pkg/managed/clusterroles.go
@@ -211,12 +211,12 @@ func newClusterRoles(binding *v1beta1v8o.VerrazzanoBinding, clusterName string) 
 			},
 			{
 				APIGroups: []string{"rbac.authorization.k8s.io"},
-				Resources: []string{"clusterroles", "roles", "rolebindings"},
+				Resources: []string{"clusterroles", "roles"},
 				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
 			},
 			{
 				APIGroups: []string{"rbac.authorization.k8s.io"},
-				Resources: []string{"clusterrolebindings"},
+				Resources: []string{"clusterrolebindings", "rolebindings"},
 				Verbs:     []string{"get", "list", "watch", "create", "update", "delete", "patch"},
 			},
 			{

--- a/pkg/managed/clusterroles.go
+++ b/pkg/managed/clusterroles.go
@@ -211,8 +211,13 @@ func newClusterRoles(binding *v1beta1v8o.VerrazzanoBinding, clusterName string) 
 			},
 			{
 				APIGroups: []string{"rbac.authorization.k8s.io"},
-				Resources: []string{"clusterroles", "clusterrolebindings", "roles", "rolebindings"},
+				Resources: []string{"clusterroles", "roles", "rolebindings"},
 				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"clusterrolebindings"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "delete", "patch"},
 			},
 			{
 				APIGroups: []string{"weblogic.oracle"},


### PR DESCRIPTION
This pull request fixes a permission error when adding/removing a domain namespace for a weblogic-kubernetes-operator. 

Change was to add the patch permission for clusterrolebinding and rolebinding to the verrazzano-system clusterrole.

Jira: https://jira.oraclecorp.com/jira/browse/VZ-953