### PR TITLE
Add unit tests for verrazzano-operator istio.go (DestinationRule & AuthorizationPolicy)

### DIFF
--- a/pkg/managed/istio.go
+++ b/pkg/managed/istio.go
@@ -173,13 +173,16 @@ func CreateServiceEntries(mbPair *types.ModelBindingPair, availableManagedCluste
 }
 
 func CreateDestinationRules(mbPair *types.ModelBindingPair, availableManagedClusterConnections map[string]*util.ManagedClusterConnection) error {
-	glog.V(6).Infof("Creating/updating DestinationRules for VerrazzanoBinding %s", mbPair.Binding.Name)
-
 	// Parse out the managed clusters that this binding applies to
 	filteredConnections, err := util.GetManagedClustersForVerrazzanoBinding(mbPair, availableManagedClusterConnections)
 	if err != nil {
 		return err
 	}
+	return createDestinationRules(mbPair, filteredConnections)
+}
+
+func createDestinationRules(mbPair *types.ModelBindingPair, filteredConnections map[string]*util.ManagedClusterConnection) error {
+	glog.V(6).Infof("Creating/updating DestinationRules for VerrazzanoBinding %s", mbPair.Binding.Name)
 
 	// Construct istio destination rules for each ManagedCluster
 	for clusterName, managedClusterObj := range mbPair.ManagedClusters {
@@ -227,13 +230,17 @@ func CreateDestinationRules(mbPair *types.ModelBindingPair, availableManagedClus
 }
 
 func CreateAuthorizationPolicies(mbPair *types.ModelBindingPair, availableManagedClusterConnections map[string]*util.ManagedClusterConnection) error {
-	glog.V(6).Infof("Creating/updating AuthorizationPolicies for VerrazzanoBinding %s", mbPair.Binding.Name)
-
 	// Parse out the managed clusters that this binding applies to
 	filteredConnections, err := util.GetManagedClustersForVerrazzanoBinding(mbPair, availableManagedClusterConnections)
 	if err != nil {
 		return err
 	}
+
+	return createAuthorizationPolicies(mbPair, filteredConnections)
+}
+
+func createAuthorizationPolicies(mbPair *types.ModelBindingPair, filteredConnections map[string]*util.ManagedClusterConnection) error {
+	glog.V(6).Infof("Creating/updating AuthorizationPolicies for VerrazzanoBinding %s", mbPair.Binding.Name)
 
 	// Construct istio authorization policies for each ManagedCluster
 	for clusterName, managedClusterObj := range mbPair.ManagedClusters {
@@ -728,14 +735,14 @@ func newDestinationRules(mbPair *types.ModelBindingPair, mc *types.ManagedCluste
 	return rules, nil
 }
 
-// Construct the traffice policy needed for Coherence extend ports.  These
+// Construct the traffic policy needed for Coherence extend ports.  These
 // ports need TLS disabled.
 func getCohTrafficPolicy(cohPorts []uint32) []*istio.TrafficPolicy_PortTrafficPolicy {
 	var tps []*istio.TrafficPolicy_PortTrafficPolicy
-	for _, port := range cohPorts{
+	for _, port := range cohPorts {
 		tp := istio.TrafficPolicy_PortTrafficPolicy{
 			Port: &istio.PortSelector{
-				Number:               port,
+				Number: port,
 			},
 			Tls: &istio.ClientTLSSettings{
 				Mode: istio.ClientTLSSettings_DISABLE,

--- a/pkg/managed/istio_test.go
+++ b/pkg/managed/istio_test.go
@@ -4,16 +4,173 @@
 package managed
 
 import (
+	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano-operator/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	istio "github.com/verrazzano/verrazzano-crd-generator/pkg/apis/networking.istio.io/v1alpha3"
+	istio2 "istio.io/api/networking/v1alpha3"
 
 	"github.com/stretchr/testify/assert"
 
 	v8o "github.com/verrazzano/verrazzano-crd-generator/pkg/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano-operator/pkg/types"
 )
+
+func TestCreateDestinationRules(t *testing.T) {
+	modelBindingPair := getModelBindingPair()
+	clusterConnections := getManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster1"]
+
+	// create the destination rules
+	err := createDestinationRules(modelBindingPair, clusterConnections)
+	if err != nil {
+		t.Fatal("can't create destination rules")
+	}
+	assertCreateDestinationRules(t, clusterConnection, 9000)
+
+	// change the coherence extend port in the model
+	modelBindingPair.Model.Spec.CoherenceClusters[0].Ports[0].Port = 9001
+	// create the destination rules
+	err = createDestinationRules(modelBindingPair, clusterConnections)
+	if err != nil {
+		t.Fatal("can't create destination rules")
+	}
+	assertCreateDestinationRules(t, clusterConnection, 9001)
+}
+
+func assertCreateDestinationRules(t *testing.T, clusterConnection *util.ManagedClusterConnection, cohPort int) {
+	// test-destination-rule
+	list, err := clusterConnection.IstioAuthClientSet.NetworkingV1alpha3().DestinationRules("test").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal("expected to find DestinationRules in test namespace")
+	}
+	assert.Equal(t, 1, len(list.Items), "should only be 1 DestinationRule in test namespace")
+	rule, err := clusterConnection.IstioAuthClientSet.NetworkingV1alpha3().DestinationRules("test").Get(context.TODO(), "test-destination-rule", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal("expected to find DestinationRule test-destination-rule")
+	}
+	assert.Equal(t, "test", rule.Namespace)
+	assert.Equal(t, istio2.ClientTLSSettings_ISTIO_MUTUAL, rule.Spec.TrafficPolicy.Tls.Mode)
+	assert.Equal(t, 1, len(rule.Spec.TrafficPolicy.PortLevelSettings))
+	assert.Equal(t, istio2.ClientTLSSettings_DISABLE, rule.Spec.TrafficPolicy.PortLevelSettings[0].Tls.Mode)
+	assert.Equal(t, cohPort, int(rule.Spec.TrafficPolicy.PortLevelSettings[0].Port.Number))
+
+	// test2-destination-rule
+	list, err = clusterConnection.IstioAuthClientSet.NetworkingV1alpha3().DestinationRules("test2").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal("expected to find DestinationRules in test2 namespace")
+	}
+	assert.Equal(t, 1, len(list.Items), "should only be 1 DestinationRule in test2 namespace")
+	rule, err = clusterConnection.IstioAuthClientSet.NetworkingV1alpha3().DestinationRules("test2").Get(context.TODO(), "test2-destination-rule", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal("expected to find DestinationRule test2-destination-rule")
+	}
+	assert.Equal(t, "test2", rule.Namespace)
+	assert.Equal(t, istio2.ClientTLSSettings_ISTIO_MUTUAL, rule.Spec.TrafficPolicy.Tls.Mode)
+	assert.Nil(t, rule.Spec.TrafficPolicy.PortLevelSettings)
+
+	// test3-destination-rule
+	list, err = clusterConnection.IstioAuthClientSet.NetworkingV1alpha3().DestinationRules("test3").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal("expected to find DestinationRules in test2 namespace")
+	}
+	assert.Equal(t, 1, len(list.Items), "should only be 1 DestinationRule in test3 namespace")
+	rule, err = clusterConnection.IstioAuthClientSet.NetworkingV1alpha3().DestinationRules("test3").Get(context.TODO(), "test3-destination-rule", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal("expected to find DestinationRule test3-destination-rule")
+	}
+	assert.Equal(t, "test3", rule.Namespace)
+	assert.Equal(t, istio2.ClientTLSSettings_ISTIO_MUTUAL, rule.Spec.TrafficPolicy.Tls.Mode)
+	assert.Nil(t, rule.Spec.TrafficPolicy.PortLevelSettings)
+}
+
+func TestCreateAuthorizationPolicies(t *testing.T) {
+	clusterConnections := getManagedClusterConnections()
+	modelBindingPair := getModelBindingPair()
+	clusterConnection := clusterConnections["cluster1"]
+
+	// create the authorization policies
+	err := createAuthorizationPolicies(modelBindingPair, clusterConnections)
+	if err != nil {
+		t.Fatal("can't create authorization policies")
+	}
+	assertCreateAuthorizationPolicies(t, clusterConnection, true)
+
+	// change the WebLogic domain connections in the model
+	modelBindingPair.Model.Spec.WeblogicDomains[0].Connections = nil
+
+	// recreate the authorization policies
+	err = createAuthorizationPolicies(modelBindingPair, clusterConnections)
+	if err != nil {
+		t.Fatal(" should not raise an error")
+	}
+	assertCreateAuthorizationPolicies(t, clusterConnection, false)
+}
+
+func assertCreateAuthorizationPolicies(t *testing.T, clusterConnection *util.ManagedClusterConnection, wlsHasConn bool) {
+  
+	// test-authorization-policy
+	list, err := clusterConnection.IstioAuthClientSet.SecurityV1beta1().AuthorizationPolicies("test").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal("expected to find AuthorizationPolicies in test namespace")
+	}
+	assert.Equal(t, 1, len(list.Items), "should only be 1 AuthorizationPolicy in test namespace")
+	policy, err := clusterConnection.IstioAuthClientSet.SecurityV1beta1().AuthorizationPolicies("test").Get(context.TODO(), "test-authorization-policy", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal("expected to find AuthorizationPolicy test-authorization-policy")
+	}
+	assert.Equal(t, "test", policy.Namespace)
+	assert.Equal(t, 1, len(policy.Spec.Rules))
+	assert.Equal(t, 2, len(policy.Spec.Rules[0].From))
+	assert.Equal(t, 2, len(policy.Spec.Rules[0].From[0].Source.Namespaces))
+	assert.Equal(t, "test", policy.Spec.Rules[0].From[0].Source.Namespaces[0])
+	assert.Equal(t, "istio-system", policy.Spec.Rules[0].From[0].Source.Namespaces[1])
+
+	// test2-authorization-policy
+	list, err = clusterConnection.IstioAuthClientSet.SecurityV1beta1().AuthorizationPolicies("test2").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal("expected to find AuthorizationPolicies in test2 namespace")
+	}
+	assert.Equal(t, 1, len(list.Items), "should only be 1 AuthorizationPolicy in test2 namespace")
+	policy, err = clusterConnection.IstioAuthClientSet.SecurityV1beta1().AuthorizationPolicies("test2").Get(context.TODO(), "test2-authorization-policy", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal("expected to find AuthorizationPolicy test2-authorization-policy")
+	}
+	assert.Equal(t, "test2", policy.Namespace)
+	assert.Equal(t, 1, len(policy.Spec.Rules))
+	assert.Equal(t, 2, len(policy.Spec.Rules[0].From))
+	if wlsHasConn {
+		assert.Equal(t, 3, len(policy.Spec.Rules[0].From[0].Source.Namespaces))
+		assert.Equal(t, "test2", policy.Spec.Rules[0].From[0].Source.Namespaces[0])
+		assert.Equal(t, "test3", policy.Spec.Rules[0].From[0].Source.Namespaces[1])
+		assert.Equal(t, "istio-system", policy.Spec.Rules[0].From[0].Source.Namespaces[2])
+	} else {
+		assert.Equal(t, 2, len(policy.Spec.Rules[0].From[0].Source.Namespaces))
+		assert.Equal(t, "test2", policy.Spec.Rules[0].From[0].Source.Namespaces[0])
+		assert.Equal(t, "istio-system", policy.Spec.Rules[0].From[0].Source.Namespaces[1])
+	}
+
+	// test3-authorization-policy
+	list, err = clusterConnection.IstioAuthClientSet.SecurityV1beta1().AuthorizationPolicies("test3").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal("expected to find AuthorizationPolicies in test3 namespace")
+	}
+	assert.Equal(t, 1, len(list.Items), "should only be 1 AuthorizationPolicy in test3 namespace")
+	policy, err = clusterConnection.IstioAuthClientSet.SecurityV1beta1().AuthorizationPolicies("test3").Get(context.TODO(), "test3-authorization-policy", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal("expected find AuthorizationPolicy test3-authorization-policy")
+	}
+	assert.Equal(t, "test3", policy.Namespace)
+	assert.Equal(t, 1, len(policy.Spec.Rules))
+	assert.Equal(t, 2, len(policy.Spec.Rules[0].From))
+	assert.Equal(t, 3, len(policy.Spec.Rules[0].From[0].Source.Namespaces))
+	assert.Equal(t, "test3", policy.Spec.Rules[0].From[0].Source.Namespaces[0])
+	assert.Equal(t, "test", policy.Spec.Rules[0].From[0].Source.Namespaces[1])
+	assert.Equal(t, "istio-system", policy.Spec.Rules[0].From[0].Source.Namespaces[2])
+}
 
 func TestNewIngresses(t *testing.T) {
 	ingressName := "bobs-ingress"

--- a/pkg/managed/testutils.go
+++ b/pkg/managed/testutils.go
@@ -1,0 +1,226 @@
+// Copyright (C) 2020, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+// Utilities used for unit testing.
+package managed
+
+import (
+  v13 "github.com/verrazzano/verrazzano-crd-generator/pkg/apis/coherence/v1"
+  "github.com/verrazzano/verrazzano-crd-generator/pkg/apis/verrazzano/v1beta1"
+  clientset "github.com/verrazzano/verrazzano-crd-generator/pkg/client/clientset/versioned/fake"
+  cohcluclientset "github.com/verrazzano/verrazzano-crd-generator/pkg/clientcoherence/clientset/versioned/fake"
+  istioClientset "github.com/verrazzano/verrazzano-crd-generator/pkg/clientistio/clientset/versioned/fake"
+  domclientset "github.com/verrazzano/verrazzano-crd-generator/pkg/clientwks/clientset/versioned/fake"
+  "github.com/verrazzano/verrazzano-operator/pkg/types"
+  "github.com/verrazzano/verrazzano-operator/pkg/util"
+  istioAuthClientset "istio.io/client-go/pkg/clientset/versioned/fake"
+  "k8s.io/api/core/v1"
+  apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+  v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  "k8s.io/apimachinery/pkg/labels"
+  "k8s.io/client-go/kubernetes/fake"
+  corelistersv1 "k8s.io/client-go/listers/core/v1"
+)
+
+// Fake PodLister implementation.  Used for unit testing.
+type fakePodLister struct {
+  pods []*v1.Pod
+}
+
+// List lists all Pods in the indexer.
+func (s *fakePodLister) List(labels.Selector) (ret []*v1.Pod, err error) {
+  // TODO: The selector is not currently needed and is ignored
+  return s.pods, nil
+}
+
+// Pods returns an object that can list and get Pods.
+func (s *fakePodLister) Pods(string) corelistersv1.PodNamespaceLister {
+  // TODO: This is not currently needed and only implemented to satisfy the PodLister interface
+  panic("implement me")
+}
+
+// Get a pod for testing that is populated with the given name, namespace and IP.
+func getPod(name string, ns string, podIP string) *v1.Pod {
+  return &v1.Pod{
+    ObjectMeta: v12.ObjectMeta{
+      Name:      name,
+      Namespace: ns,
+    },
+    Status: v1.PodStatus{
+      PodIP: podIP,
+    },
+  }
+}
+
+// Get a test map of managed cluster connections that use client set fakes,
+func getManagedClusterConnections() map[string]*util.ManagedClusterConnection {
+  // create a ManagedClusterConnection that uses client set fakes
+  clusterConnection := &util.ManagedClusterConnection{
+    KubeClient:                  fake.NewSimpleClientset(),
+    KubeExtClientSet:            apiextensionsclient.NewSimpleClientset(),
+    VerrazzanoOperatorClientSet: clientset.NewSimpleClientset(),
+    DomainClientSet:             domclientset.NewSimpleClientset(),
+    CohClusterClientSet:         cohcluclientset.NewSimpleClientset(),
+    IstioClientSet:              istioClientset.NewSimpleClientset(),
+    IstioAuthClientSet:          istioAuthClientset.NewSimpleClientset(),
+  }
+  // set a fake pod lister on the cluster connection
+  clusterConnection.PodLister = &fakePodLister{
+    pods: []*v1.Pod{
+      getPod("prometheus-pod", "istio-system", "123.99.0.1"),
+      getPod("test-pod", "test", "123.99.0.2"),
+      getPod("test2-pod", "test2", "123.99.0.3"),
+      getPod("test3-pod", "test3", "123.99.0.4"),
+    },
+  }
+
+  return map[string]*util.ManagedClusterConnection{
+    "cluster1": clusterConnection,
+  }
+}
+
+// Get a test model binding pair.
+func getModelBindingPair() *types.ModelBindingPair {
+  var pair = &types.ModelBindingPair{
+    Model: &v1beta1.VerrazzanoModel{
+      ObjectMeta: v12.ObjectMeta{
+        Name: "testModel",
+      },
+      Spec: v1beta1.VerrazzanoModelSpec{
+        Description: "",
+        WeblogicDomains: []v1beta1.VerrazzanoWebLogicDomain{
+          {
+            Name: "test-weblogic",
+            Connections: []v1beta1.VerrazzanoConnections{
+              {
+                Ingress: []v1beta1.VerrazzanoIngressConnection{
+                  {
+                    Name: "test-ingress",
+                  },
+                },
+                Rest: []v1beta1.VerrazzanoRestConnection{
+                  {
+                    Target: "test-helidon",
+                  },
+                },
+              },
+            },
+          },
+        },
+        CoherenceClusters: []v1beta1.VerrazzanoCoherenceCluster{
+          {
+            Name: "test-coherence",
+            Ports: []v13.NamedPortSpec{
+              {
+                Name: "extend",
+                PortSpec: v13.PortSpec{
+                  Port: 9000,
+                },
+              },
+            },
+            Connections: []v1beta1.VerrazzanoConnections{
+              {
+                Ingress: []v1beta1.VerrazzanoIngressConnection{
+                  {
+                    Name: "test-ingress",
+                  },
+                },
+                Rest: []v1beta1.VerrazzanoRestConnection{
+                  {
+                    Target: "test-weblogic",
+                  },
+                },
+              },
+            },
+          },
+        },
+        HelidonApplications: []v1beta1.VerrazzanoHelidon{
+          {
+            Name:       "test-helidon",
+            Port:       8001,
+            TargetPort: 8002,
+            Connections: []v1beta1.VerrazzanoConnections{
+              {
+                Ingress: []v1beta1.VerrazzanoIngressConnection{
+                  {
+                    Name: "test-ingress",
+                  },
+                },
+                Coherence: []v1beta1.VerrazzanoCoherenceConnection{
+                  {
+                    Target: "test-coherence",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    Binding: &v1beta1.VerrazzanoBinding{
+      ObjectMeta: v12.ObjectMeta{
+        Name: "testBinding",
+      },
+      Spec: v1beta1.VerrazzanoBindingSpec{
+        Placement: []v1beta1.VerrazzanoPlacement{
+          {
+            Name: "local",
+            Namespaces: []v1beta1.KubernetesNamespace{
+              {
+                Name: "test",
+                Components: []v1beta1.BindingComponent{
+                  {
+                    Name: "test-coherence",
+                  },
+                },
+              },
+              {
+                Name: "test2",
+                Components: []v1beta1.BindingComponent{
+                  {
+                    Name: "test-helidon",
+                  },
+                },
+              },
+              {
+                Name: "test3",
+                Components: []v1beta1.BindingComponent{
+                  {
+                    Name: "test-weblogic",
+                  },
+                },
+              },
+            },
+          },
+        },
+        IngressBindings: []v1beta1.VerrazzanoIngressBinding{
+          {
+            Name:    "test-ingress",
+            DnsName: "*",
+          },
+        },
+      },
+    },
+    ManagedClusters: map[string]*types.ManagedCluster{
+      "cluster1": {
+        Name:       "cluster1",
+        Namespaces: []string{"default", "test", "test2", "test3"},
+        Ingresses: map[string][]*types.Ingress{
+          "ingress1": {
+            {
+              Name: "test-ingress",
+              Destination: []*types.IngressDestination{
+                {
+                  Host:       "testhost",
+                  Port:       8888,
+                  DomainName: "test.com",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  }
+  return pair
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -38,7 +38,7 @@ import (
 
 // Structure maintaining the connection details to a ManagedCluster
 type ManagedClusterConnection struct {
-	KubeClient                  *kubernetes.Clientset
+	KubeClient                  kubernetes.Interface
 	KubeExtClientSet            apiextensionsclient.Interface
 	VerrazzanoOperatorClientSet clientset.Interface
 	WlsOprClientSet             wlsoprclientset.Interface


### PR DESCRIPTION
Part of a larger effort to improve unit test coverage.  
Add missing unit tests for istio.go in verrazzano-operator.

- Refactor util.ManagedClusterConnection to use interface (kubernetes.Interface)
- Refactor istio.go methods to pass in cluster connections (mock friendly)
- Add unit tests for DestinationRule and AuthorizationPolicy creation
- Add test utility for creating mock cluster connections (importing fake packages for client set interfaces)
