### PR TITLE
Add optional startup parameter to pass an imagePullSecret

### DIFF
--- a/cmd/verrazzano-operator/main.go
+++ b/cmd/verrazzano-operator/main.go
@@ -35,6 +35,7 @@ var (
 	helidonAppOperatorDeployment string
 	enableMonitoringStorage      string
 	apiServerRealm               string
+	imagePullSecret              string
 )
 
 // homePage provides a default handler for unmatched patterns
@@ -123,7 +124,7 @@ func main() {
 		glog.V(6).Info("helidonAppOperatorDeployment Disabled")
 		manifest.HelidonAppOperatorImage = ""
 	}
-	controller, err := pkgverrazzanooperator.NewController(kubeconfig, manifest, masterURL, watchNamespace, verrazzanoUri, enableMonitoringStorage)
+	controller, err := pkgverrazzanooperator.NewController(kubeconfig, manifest, masterURL, watchNamespace, verrazzanoUri, enableMonitoringStorage, imagePullSecret)
 	if err != nil {
 		glog.Fatalf("Error creating the controller: %s", err.Error())
 	}
@@ -167,4 +168,5 @@ func init() {
 	flag.StringVar(&helidonAppOperatorDeployment, "helidonAppOperatorDeployment", "", "--helidonAppOperatorDeployment=false disables helidonAppOperatorDeployment")
 	flag.StringVar(&enableMonitoringStorage, "enableMonitoringStorage", "", "Enable storage for monitoring.  The default is true. 'false' means monitoring storage is disabled.")
 	flag.StringVar(&apiServerRealm, "apiServerRealm", "", "API Server Realm on Keycloak")
+	flag.StringVar(&imagePullSecret, "imagePullSecret", "", "Optional imagePullSecret to add to service accounts created by the operator")
 }

--- a/pkg/controller/model_binding_pair.go
+++ b/pkg/controller/model_binding_pair.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func CreateModelBindingPair(model *v1beta1v8o.VerrazzanoModel, binding *v1beta1v8o.VerrazzanoBinding, verrazzanoUri string) *types.ModelBindingPair {
+func CreateModelBindingPair(model *v1beta1v8o.VerrazzanoModel, binding *v1beta1v8o.VerrazzanoBinding, verrazzanoUri string, imagePullSecret string) *types.ModelBindingPair {
 
 	mbPair := &types.ModelBindingPair{
 		Model:           model,
@@ -33,6 +33,7 @@ func CreateModelBindingPair(model *v1beta1v8o.VerrazzanoModel, binding *v1beta1v
 		ManagedClusters: map[string]*types.ManagedCluster{},
 		Lock:            sync.RWMutex{},
 		VerrazzanoUri:   verrazzanoUri,
+		ImagePullSecret: imagePullSecret,
 	}
 	return buildModelBindingPair(mbPair)
 }
@@ -46,8 +47,8 @@ func releaseLock(mbPair *types.ModelBindingPair) {
 }
 
 // Update a model/binding pair by rebuilding it
-func UpdateModelBindingPair(mbPair *types.ModelBindingPair, model *v1beta1v8o.VerrazzanoModel, binding *v1beta1v8o.VerrazzanoBinding, verrazzanoUri string) {
-	newMBPair := CreateModelBindingPair(model, binding, verrazzanoUri)
+func UpdateModelBindingPair(mbPair *types.ModelBindingPair, model *v1beta1v8o.VerrazzanoModel, binding *v1beta1v8o.VerrazzanoBinding, verrazzanoUri string, imagePullSecret string) {
+	newMBPair := CreateModelBindingPair(model, binding, verrazzanoUri, imagePullSecret)
 	lock := mbPair.Lock
 	lock.Lock()
 	defer lock.Unlock()

--- a/pkg/controller/model_binding_pair_test.go
+++ b/pkg/controller/model_binding_pair_test.go
@@ -110,7 +110,8 @@ func TestSockShopIngressBindings(t *testing.T) {
 	cluster := "cluster1"
 	namespace := "sockshop"
 	vzUri := "Verrazzano.Uri"
-	pair := CreateModelBindingPair(model, binding, vzUri)
+	optImagePullSecret := ""
+	pair := CreateModelBindingPair(model, binding, vzUri, optImagePullSecret)
 
 	validateIngressBindings(t, pair, cluster, namespace, "wl-frontend-cluster-cluster-1.sockshop.svc.cluster.local", 8001)
 }
@@ -160,7 +161,8 @@ func TestSockShopSimpleModelBinding(t *testing.T) {
 	cluster := "local"
 	namespace := "sockshop"
 	vzUri := "Verrazzano.Uri"
-	pair := CreateModelBindingPair(model, binding, vzUri)
+	optImagePullSecret := ""
+	pair := CreateModelBindingPair(model, binding, vzUri, optImagePullSecret)
 
 	assertPorts(t, pair, cluster, namespace, "frontend", 8080, 8079)
 	assertPorts(t, pair, cluster, namespace, "carts", 80, 7001)
@@ -169,14 +171,14 @@ func TestSockShopSimpleModelBinding(t *testing.T) {
 	assertPorts(t, pair, cluster, namespace, "swagger", 80, 8080)
 
 	//Test default ports
-	apps := []v8o.VerrazzanoHelidon{}
+	var apps []v8o.VerrazzanoHelidon
 	for _, helidon := range model.Spec.HelidonApplications {
 		helidon.Port = 0
 		helidon.TargetPort = 0
 		apps = append(apps, helidon)
 	}
 	model.Spec.HelidonApplications = apps
-	pair = CreateModelBindingPair(model, binding, vzUri)
+	pair = CreateModelBindingPair(model, binding, vzUri, optImagePullSecret)
 	assertPorts(t, pair, cluster, namespace, "frontend", 8080, 8080)
 	assertPorts(t, pair, cluster, namespace, "carts", 8080, 8080)
 	assertPorts(t, pair, cluster, namespace, "user", 8080, 8080)
@@ -256,7 +258,8 @@ func TestCreateModelBindingPair(t *testing.T) {
 	assert.NotEmpty(t, binding.Name)
 
 	// create a new ModelBindingPair
-	mbp := CreateModelBindingPair(model, binding, "/my/verrazzano/url")
+	optImagePullSecret := ""
+	mbp := CreateModelBindingPair(model, binding, "/my/verrazzano/url", optImagePullSecret)
 
 	// gather expected state
 	expectedClusterHelidonApps := map[string]map[string]struct{}{"cluster1": {"frontend": {}, "carts": {},
@@ -266,12 +269,13 @@ func TestCreateModelBindingPair(t *testing.T) {
 		Spec: wls.DomainSpec{Image: util.GetTestWlsFrontendImage(), LogHome: "/u01/oracle/user_projects/domains/wl-frontend/logs"}}
 
 	expectedValues := MbpExpectedValues{
-		Binding:     binding,
-		Model:       model,
-		HelidonApps: expectedClusterHelidonApps,
-		Namespaces:  expectedClusterNamespaces,
-		WlsDomains:  map[string]map[string]*wls.Domain{"cluster1": {"wl-frontend": wlsDomain}},
-		Uri:         "/my/verrazzano/url",
+		Binding:         binding,
+		Model:           model,
+		HelidonApps:     expectedClusterHelidonApps,
+		Namespaces:      expectedClusterNamespaces,
+		WlsDomains:      map[string]map[string]*wls.Domain{"cluster1": {"wl-frontend": wlsDomain}},
+		Uri:             "/my/verrazzano/url",
+		ImagePullSecret: optImagePullSecret,
 	}
 	// validate the returned mbp
 	validateModelBindingPair(t, mbp, expectedValues)
@@ -291,7 +295,8 @@ func TestCreateModelBindingPairNoCluster(t *testing.T) {
 	cluster := "cluster1"
 	namespace := "sockshop"
 	vzUri := "/my/verrazzano/url"
-	mbp := CreateModelBindingPair(model, binding, vzUri)
+	optImagePullSecret := "testSecret"
+	mbp := CreateModelBindingPair(model, binding, vzUri, optImagePullSecret)
 
 	// gather expected state
 	expectedClusterHelidonApps := map[string]map[string]struct{}{"cluster1": {"frontend": {}, "carts": {},
@@ -301,12 +306,13 @@ func TestCreateModelBindingPairNoCluster(t *testing.T) {
 		Spec: wls.DomainSpec{Image: util.GetTestWlsFrontendImage(), LogHome: "/u01/oracle/user_projects/domains/wl-frontend/logs"}}
 
 	expectedValues := MbpExpectedValues{
-		Binding:     binding,
-		Model:       model,
-		HelidonApps: expectedClusterHelidonApps,
-		Namespaces:  expectedClusterNamespaces,
-		WlsDomains:  map[string]map[string]*wls.Domain{"cluster1": {"wl-frontend": wlsDomain}},
-		Uri:         "/my/verrazzano/url",
+		Binding:         binding,
+		Model:           model,
+		HelidonApps:     expectedClusterHelidonApps,
+		Namespaces:      expectedClusterNamespaces,
+		WlsDomains:      map[string]map[string]*wls.Domain{"cluster1": {"wl-frontend": wlsDomain}},
+		Uri:             "/my/verrazzano/url",
+		ImagePullSecret: optImagePullSecret,
 	}
 
 	validateModelBindingPair(t, mbp, expectedValues)
@@ -334,7 +340,8 @@ func TestUpdateModelBindingPair(t *testing.T) {
 	assert.NotEmpty(t, binding2.Name)
 
 	// create a new ModelBindingPair
-	mbp := CreateModelBindingPair(model, binding, "/my/verrazzano/url")
+	optImagePullSecret := "testSecret"
+	mbp := CreateModelBindingPair(model, binding, "/my/verrazzano/url", optImagePullSecret)
 
 	// gather expected state
 	expectedClusterHelidonApps := map[string]map[string]struct{}{"cluster1": {"frontend": {}, "carts": {}, "catalogue": {},
@@ -343,18 +350,20 @@ func TestUpdateModelBindingPair(t *testing.T) {
 	wlsDomain := &wls.Domain{ObjectMeta: metav1.ObjectMeta{Name: "wl-frontend", Namespace: "sockshop"},
 		Spec: wls.DomainSpec{Image: util.GetTestWlsFrontendImage(), LogHome: "/u01/oracle/user_projects/domains/wl-frontend/logs"}}
 	expectedValues := MbpExpectedValues{
-		Binding:     binding,
-		Model:       model,
-		HelidonApps: expectedClusterHelidonApps,
-		Namespaces:  expectedClusterNamespaces,
-		WlsDomains:  map[string]map[string]*wls.Domain{"cluster1": {"wl-frontend": wlsDomain}},
-		Uri:         "/my/verrazzano/url",
+		Binding:         binding,
+		Model:           model,
+		HelidonApps:     expectedClusterHelidonApps,
+		Namespaces:      expectedClusterNamespaces,
+		WlsDomains:      map[string]map[string]*wls.Domain{"cluster1": {"wl-frontend": wlsDomain}},
+		Uri:             "/my/verrazzano/url",
+		ImagePullSecret: optImagePullSecret,
 	}
 	// validate create mbp
 	validateModelBindingPair(t, mbp, expectedValues)
 
 	// invoke update function that we are testing
-	UpdateModelBindingPair(mbp, model2, binding2, "/my/verrazzano/url/updated")
+	optImagePullSecretUpdated := "testSecretUpdated"
+	UpdateModelBindingPair(mbp, model2, binding2, "/my/verrazzano/url/updated", optImagePullSecretUpdated)
 
 	// gather updated state
 	expectedClusterHelidonApps = map[string]map[string]struct{}{"cluster1": {"frontend": {}, "orders": {}},
@@ -363,12 +372,13 @@ func TestUpdateModelBindingPair(t *testing.T) {
 		"cluster2": {"verrazzano-system": {}, "sockshop2": {}}}
 
 	expectedValues = MbpExpectedValues{
-		Binding:     binding2,
-		Model:       model2,
-		HelidonApps: expectedClusterHelidonApps,
-		Namespaces:  expectedClusterNamespaces,
-		WlsDomains:  map[string]map[string]*wls.Domain{},
-		Uri:         "/my/verrazzano/url/updated",
+		Binding:         binding2,
+		Model:           model2,
+		HelidonApps:     expectedClusterHelidonApps,
+		Namespaces:      expectedClusterNamespaces,
+		WlsDomains:      map[string]map[string]*wls.Domain{},
+		Uri:             "/my/verrazzano/url/updated",
+		ImagePullSecret: optImagePullSecretUpdated,
 	}
 	// validate updated mbp
 	validateModelBindingPair(t, mbp, expectedValues)
@@ -379,7 +389,8 @@ func TestDatabaseBindings(t *testing.T) {
 	binding, _ := ReadBinding("testdata/sockshop-binding.yaml")
 
 	// create a new ModelBindingPair
-	mbp := CreateModelBindingPair(model, binding, "/my/verrazzano/url")
+	optImagePullSecret := ""
+	mbp := CreateModelBindingPair(model, binding, "/my/verrazzano/url", optImagePullSecret)
 
 	// validate the returned mbp
 	validateDatabaseBindings(t, mbp, "cluster-1")
@@ -387,12 +398,13 @@ func TestDatabaseBindings(t *testing.T) {
 
 // MbpExpectedValues is a struct of expected ModelBindingPair state used in assertions
 type MbpExpectedValues struct {
-	Binding     *v8o.VerrazzanoBinding
-	Model       *v8o.VerrazzanoModel
-	HelidonApps map[string]map[string]struct{}
-	Namespaces  map[string]map[string]struct{}
-	WlsDomains  map[string]map[string]*wls.Domain
-	Uri         string
+	Binding         *v8o.VerrazzanoBinding
+	Model           *v8o.VerrazzanoModel
+	HelidonApps     map[string]map[string]struct{}
+	Namespaces      map[string]map[string]struct{}
+	WlsDomains      map[string]map[string]*wls.Domain
+	Uri             string
+	ImagePullSecret string
 }
 
 // validateModelBindingPair validates a ModelBindingPair
@@ -401,6 +413,7 @@ func validateModelBindingPair(t *testing.T,
 	expectedValues MbpExpectedValues) {
 
 	assert.Equal(t, expectedValues.Uri, mbp.VerrazzanoUri)
+	assert.Equal(t, expectedValues.ImagePullSecret, mbp.ImagePullSecret)
 	assert.True(t, reflect.DeepEqual(expectedValues.Model, mbp.Model), "Models should be equal")
 	assert.True(t, reflect.DeepEqual(expectedValues.Binding, mbp.Binding), "Bindings should be equal")
 	managedClusters := mbp.ManagedClusters

--- a/pkg/managed/serviceaccount.go
+++ b/pkg/managed/serviceaccount.go
@@ -37,10 +37,10 @@ func CreateServiceAccounts(mbPair *types.ModelBindingPair, availableManagedClust
 		if mbPair.Binding.Name == constants.VmiSystemBindingName {
 			// Add add the service accounts needed for monitoring and logging
 			for _, serviceAccountName := range monitoring.GetMonitoringComponents() {
-				serviceAccounts = append(serviceAccounts, newServiceAccounts(mbPair.Binding, managedClusterObj, serviceAccountName, monitoring.GetMonitoringComponentLabels(clusterName, serviceAccountName), monitoring.GetMonitoringNamespace(serviceAccountName))...)
+				serviceAccounts = append(serviceAccounts, newServiceAccounts(mbPair.Binding, managedClusterObj, serviceAccountName, monitoring.GetMonitoringComponentLabels(clusterName, serviceAccountName), monitoring.GetMonitoringNamespace(serviceAccountName), mbPair.ImagePullSecret)...)
 			}
 		} else {
-			serviceAccounts = newServiceAccounts(mbPair.Binding, managedClusterObj, util.GetServiceAccountNameForSystem(), util.GetManagedLabelsNoBinding(clusterName), "")
+			serviceAccounts = newServiceAccounts(mbPair.Binding, managedClusterObj, util.GetServiceAccountNameForSystem(), util.GetManagedLabelsNoBinding(clusterName), "", mbPair.ImagePullSecret)
 		}
 
 		// Create/Update ServiceAccount
@@ -79,7 +79,7 @@ func createServiceAccount(binding *v1beta1v8o.VerrazzanoBinding, managedClusterC
 }
 
 // Constructs the necessary ServiceAccounts for the specified ManagedCluster in the given VerrazzanoBinding
-func newServiceAccounts(binding *v1beta1v8o.VerrazzanoBinding, managedCluster *types.ManagedCluster, name string, labels map[string]string, namespaceName string) []*corev1.ServiceAccount {
+func newServiceAccounts(binding *v1beta1v8o.VerrazzanoBinding, managedCluster *types.ManagedCluster, name string, labels map[string]string, namespaceName string, imagePullSecert string) []*corev1.ServiceAccount {
 	var serviceAccounts []*corev1.ServiceAccount
 
 	for _, namespace := range managedCluster.Namespaces {
@@ -96,6 +96,16 @@ func newServiceAccounts(binding *v1beta1v8o.VerrazzanoBinding, managedCluster *t
 				}(),
 				Labels: labels,
 			},
+			ImagePullSecrets: func() []corev1.LocalObjectReference {
+				imagePullSecrets := []corev1.LocalObjectReference{}
+				if len(imagePullSecert) > 0 {
+					imagePullSecret := corev1.LocalObjectReference{
+						Name: imagePullSecert,
+					}
+					imagePullSecrets = append(imagePullSecrets, imagePullSecret)
+				}
+				return imagePullSecrets
+			}(),
 		}
 		serviceAccounts = append(serviceAccounts, serviceAccount)
 		// Only add service account resource once in case of system binding

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -114,6 +114,8 @@ type ModelBindingPair struct {
 	// Lock for synchronizing write access
 	Lock sync.RWMutex
 
-	VerrazzanoUri   string
+	VerrazzanoUri string
+
+	// Optional image pull secret to add to service accounts created by the operator
 	ImagePullSecret string
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -114,5 +114,6 @@ type ModelBindingPair struct {
 	// Lock for synchronizing write access
 	Lock sync.RWMutex
 
-	VerrazzanoUri string
+	VerrazzanoUri   string
+	ImagePullSecret string
 }


### PR DESCRIPTION
Add an optional startup parameter that specifies an imagePullSecret to use for pulling images.  This secret will be added to the service accounts created by the verrazzano-operator.

This is required to support testing of verrazzano related images that have not been made public.