### PR TITLE
Unit tests for verrazzano-operator clusterroles.go

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -467,7 +467,7 @@ func (c *Controller) createManagedClusterResourcesForBinding(mbPair *types.Model
 	}
 
 	// Create ClusterRoles
-	err = managed.CreateClusterRoles(mbPair, c.managedClusterConnections)
+	err = managed.CreateClusterRoles(mbPair, filteredConnections)
 	if err != nil {
 		glog.Errorf("Failed to create cluster roles for binding %s: %v", mbPair.Binding.Name, err)
 	}
@@ -777,7 +777,7 @@ func (c *Controller) cleanupOrphanedResources(mbPair *types.ModelBindingPair) {
 	}
 
 	// Cleanup ClusterRoles
-	err = managed.CleanupOrphanedClusterRoles(mbPair, c.managedClusterConnections, c.modelBindingPairs)
+	err = managed.CleanupOrphanedClusterRoles(mbPair, c.managedClusterConnections)
 	if err != nil {
 		glog.Errorf("Failed to cleanup ClusterRoles for binding %s: %v", mbPair.Binding.Name, err)
 	}

--- a/pkg/managed/clusterroles.go
+++ b/pkg/managed/clusterroles.go
@@ -18,15 +18,103 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+var policyRules = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{""},
+		Resources: []string{"pods/log", "serviceaccounts", "pods/portforward", "nodes"},
+		Verbs:     []string{"get", "list", "watch", "create", "update", "delete", "deletecollection", "patch"},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"pods", "pods/exec", "configmaps", "endpoints", "events", "namespaces", "persistentvolumeclaims", "secrets", "services"},
+		Verbs:     []string{"*"},
+	},
+	{
+		NonResourceURLs: []string{"/version/*"},
+		Verbs:           []string{"get"},
+	},
+	{
+		APIGroups: []string{"apps"},
+		Resources: []string{"deployments", "daemonsets", "replicasets", "statefulsets"},
+		Verbs:     []string{"*"},
+	},
+	{
+		APIGroups:     []string{"apps"},
+		Resources:     []string{"deployments/finalizers"},
+		ResourceNames: []string{"coherence-operator"},
+		Verbs:         []string{"update"},
+	},
+	{
+		APIGroups: []string{"extensions"},
+		Resources: []string{"daemonsets", "replicasets", "statefulsets", "podsecuritypolicies"},
+		Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+	},
+	{
+		APIGroups: []string{"policy"},
+		Resources: []string{"podsecuritypolicies"},
+		Verbs:     []string{"get"},
+	},
+	{
+		APIGroups: []string{"batch"},
+		Resources: []string{"jobs"},
+		Verbs:     []string{"get", "list", "watch", "create", "update", "delete", "patch", "deletecollection"},
+	},
+	{
+		APIGroups: []string{"authentication.k8s.io"},
+		Resources: []string{"tokenreviews"},
+		Verbs:     []string{"create"},
+	},
+	{
+		APIGroups: []string{"authorization.k8s.io"},
+		Resources: []string{"subjectaccessreviews"},
+		Verbs:     []string{"create"},
+	},
+	{
+		APIGroups: []string{"apiextensions.k8s.io"},
+		Resources: []string{"customresourcedefinitions"},
+		Verbs:     []string{"*"},
+	},
+	{
+		APIGroups: []string{"monitoring.coreos.com"},
+		Resources: []string{"servicemonitors"},
+		Verbs:     []string{"get", "create"},
+	},
+	{
+		APIGroups: []string{"verrazzano.io"},
+		Resources: []string{"*"},
+		Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+	},
+	{
+		APIGroups: []string{"rbac.authorization.k8s.io"},
+		Resources: []string{"clusterroles", "roles"},
+		Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+	},
+	{
+		APIGroups: []string{"rbac.authorization.k8s.io"},
+		Resources: []string{"clusterrolebindings", "rolebindings"},
+		Verbs:     []string{"get", "list", "watch", "create", "update", "delete", "patch"},
+	},
+	{
+		APIGroups: []string{"weblogic.oracle"},
+		Resources: []string{"domains"},
+		Verbs:     []string{"get", "list", "watch", "create", "update", "delete", "patch", "deletecollection"},
+	},
+	{
+		APIGroups: []string{"weblogic.oracle"},
+		Resources: []string{"domains/status"},
+		Verbs:     []string{"get", "list", "watch", "update", "patch"},
+	},
+	{
+		APIGroups: []string{"coherence.oracle.com"},
+		Resources: []string{"*"},
+		Verbs:     []string{"*"},
+	},
+}
+
 // CreateClusterRoles creates/updates cluster roles needed for each managed cluster.
-func CreateClusterRoles(mbPair *types.ModelBindingPair, availableManagedClusterConnections map[string]*util.ManagedClusterConnection) error {
+func CreateClusterRoles(mbPair *types.ModelBindingPair, filteredConnections map[string]*util.ManagedClusterConnection) error {
 
 	glog.V(6).Infof("Creating/updating ClusterRoles for VerrazzanoBinding %s", mbPair.Binding.Name)
-
-	filteredConnections, err := GetFilteredConnections(mbPair, availableManagedClusterConnections)
-	if err != nil {
-		return err
-	}
 
 	// Construct ClusterRoles for each ManagedCluster
 	for clusterName := range mbPair.ManagedClusters {
@@ -60,7 +148,7 @@ func CreateClusterRoles(mbPair *types.ModelBindingPair, availableManagedClusterC
 }
 
 // CleanupOrphanedClusterRoles deletes cluster roles that have been orphaned.
-func CleanupOrphanedClusterRoles(mbPair *types.ModelBindingPair, availableManagedClusterConnections map[string]*util.ManagedClusterConnection, allMbPairs map[string]*types.ModelBindingPair) error {
+func CleanupOrphanedClusterRoles(mbPair *types.ModelBindingPair, availableManagedClusterConnections map[string]*util.ManagedClusterConnection) error {
 	glog.V(6).Infof("Cleaning up orphaned ClusterRoles for VerrazzanoBinding %s", mbPair.Binding.Name)
 
 	// Get the managed clusters that this binding does NOT apply to
@@ -146,98 +234,7 @@ func newClusterRoles(binding *v1beta1v8o.VerrazzanoBinding, clusterName string) 
 			Name:   util.GetServiceAccountNameForSystem(),
 			Labels: roleLabels,
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods/log", "serviceaccounts", "pods/portforward", "nodes"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete", "deletecollection", "patch"},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods", "pods/exec", "configmaps", "endpoints", "events", "namespaces", "persistentvolumeclaims", "secrets", "services"},
-				Verbs:     []string{"*"},
-			},
-			{
-				NonResourceURLs: []string{"/version/*"},
-				Verbs:           []string{"get"},
-			},
-			{
-				APIGroups: []string{"apps"},
-				Resources: []string{"deployments", "daemonsets", "replicasets", "statefulsets"},
-				Verbs:     []string{"*"},
-			},
-			{
-				APIGroups:     []string{"apps"},
-				Resources:     []string{"deployments/finalizers"},
-				ResourceNames: []string{"coherence-operator"},
-				Verbs:         []string{"update"},
-			},
-			{
-				APIGroups: []string{"extensions"},
-				Resources: []string{"daemonsets", "replicasets", "statefulsets", "podsecuritypolicies"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
-			},
-			{
-				APIGroups: []string{"policy"},
-				Resources: []string{"podsecuritypolicies"},
-				Verbs:     []string{"get"},
-			},
-			{
-				APIGroups: []string{"batch"},
-				Resources: []string{"jobs"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete", "patch", "deletecollection"},
-			},
-			{
-				APIGroups: []string{"authentication.k8s.io"},
-				Resources: []string{"tokenreviews"},
-				Verbs:     []string{"create"},
-			},
-			{
-				APIGroups: []string{"authorization.k8s.io"},
-				Resources: []string{"subjectaccessreviews"},
-				Verbs:     []string{"create"},
-			},
-			{
-				APIGroups: []string{"apiextensions.k8s.io"},
-				Resources: []string{"customresourcedefinitions"},
-				Verbs:     []string{"*"},
-			},
-			{
-				APIGroups: []string{"monitoring.coreos.com"},
-				Resources: []string{"servicemonitors"},
-				Verbs:     []string{"get", "create"},
-			},
-			{
-				APIGroups: []string{"verrazzano.io"},
-				Resources: []string{"*"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
-			},
-			{
-				APIGroups: []string{"rbac.authorization.k8s.io"},
-				Resources: []string{"clusterroles", "roles"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
-			},
-			{
-				APIGroups: []string{"rbac.authorization.k8s.io"},
-				Resources: []string{"clusterrolebindings", "rolebindings"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete", "patch"},
-			},
-			{
-				APIGroups: []string{"weblogic.oracle"},
-				Resources: []string{"domains"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete", "patch", "deletecollection"},
-			},
-			{
-				APIGroups: []string{"weblogic.oracle"},
-				Resources: []string{"domains/status"},
-				Verbs:     []string{"get", "list", "watch", "update", "patch"},
-			},
-			{
-				APIGroups: []string{"coherence.oracle.com"},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
-			},
-		},
+		Rules: policyRules,
 	}
 	clusterRoles = append(clusterRoles, clusterRole)
 

--- a/pkg/managed/clusterroles_test.go
+++ b/pkg/managed/clusterroles_test.go
@@ -1,0 +1,281 @@
+// Copyright (C) 2020, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package managed
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano-operator/pkg/constants"
+	"github.com/verrazzano/verrazzano-operator/pkg/monitoring"
+	"github.com/verrazzano/verrazzano-operator/pkg/testutil"
+	"github.com/verrazzano/verrazzano-operator/pkg/types"
+	"github.com/verrazzano/verrazzano-operator/pkg/util"
+	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+)
+
+// TestCleanupOrphanedClusterRoles tests the cleanup of orphaned cluster roles
+// GIVEN a cluster which has no existing cluster roles
+//  WHEN I create an orphaned cluster (not expected on the cluster) and call CleanupOrphanedClusterRoles
+//  THEN the orphaned cluster role should be cleaned up (deleted)
+func TestCleanupOrphanedClusterRoles(t *testing.T) {
+	modelBindingPair := testutil.GetModelBindingPair()
+	clusterConnections := testutil.GetManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster3"]
+
+	// create a cluster role that is not expected on the cluster
+	cr := v1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "orphaned",
+			Labels: map[string]string{
+				"verrazzano.binding": "testBinding",
+				"verrazzano.cluster": "cluster3",
+			},
+		},
+	}
+	_, err := clusterConnection.KubeClient.RbacV1().ClusterRoles().Create(context.TODO(), &cr, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("got an error trying to create a cluster role: %v", err)
+	}
+
+	// the orphaned cluster role should be cleaned up by the call to CleanupOrphanedClusterRoles
+	err = CleanupOrphanedClusterRoles(modelBindingPair, clusterConnections)
+	if err != nil {
+		t.Fatalf("got an error from CleanupOrphanedClusterRoles: %v", err)
+	}
+
+	// verify that the orphaned cluster role no longer exists
+	_, err = clusterConnection.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), "orphaned", metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("expected cluster role to be cleaned up")
+	}
+}
+
+// TestCreateClusterRoles tests creation of cluster roles
+// GIVEN a cluster which does not have a cluster role with the service account name
+//  WHEN I call CreateClusterRoles
+//  THEN there should be a cluster role with the service account created
+//   AND that cluster role should have an expected set of policy rules
+func TestCreateClusterRoles(t *testing.T) {
+	assert := assert.New(t)
+
+	modelBindingPair := testutil.GetModelBindingPair()
+	clusterConnections := testutil.GetManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster1"]
+
+	// the call to CreateClusterRoles should create a cluster role with the service account name
+	// the expectation is that it doesn't exist prior to the call
+	// verify that it doesn't exist
+	serviceAccountName := util.GetServiceAccountNameForSystem()
+	_, err := clusterConnection.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("did not expect cluster role %s to exist", serviceAccountName)
+	}
+
+	err = CreateClusterRoles(modelBindingPair, clusterConnections)
+	if err != nil {
+		t.Fatalf("got an error from CreateClusterRoles: %v", err)
+	}
+
+	// verify that a cluster role with the service account name has been created by the call to CreateClusterRoles
+	cr, err := clusterConnection.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("got an error trying to get a cluster role: %v", err)
+	}
+	// verify that the expected properties and policy rules are set on the new cluster role
+	assert.Equal(serviceAccountName, cr.Name, "the name of the cluster role should be %s", serviceAccountName)
+	assertGivenRoleHasExpectedRules(t, cr, policyRules)
+}
+
+// TestCreateClusterRolesVmiSystem tests creation of cluster roles when the binding name is 'system'
+// GIVEN a cluster which has no cluster roles
+//  WHEN I call CreateClusterRoles with a binding named 'system'
+//  THEN there should be an expected set of system cluster roles
+//   AND each system cluster role should have an expected set of policy rules
+func TestCreateClusterRolesVmiSystem(t *testing.T) {
+	modelBindingPair := testutil.GetModelBindingPair()
+	clusterConnections := testutil.GetManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster1"]
+
+	// change the binding name to the VmiSystemBindingName so that CreateClusterRoles creates the system cluster roles
+	modelBindingPair.Binding.Name = constants.VmiSystemBindingName
+
+	err := CreateClusterRoles(modelBindingPair, clusterConnections)
+	if err != nil {
+		t.Fatalf("got an error from CreateClusterRoles: %v", err)
+	}
+
+	// it is expected that after the call to CreateClusterRoles that all of the system cluster roles exist
+	expectedRoles := monitoring.GetSystemClusterRoles("cluster1")
+
+	// make sure that all of the expected roles exist
+	for _, expected := range expectedRoles {
+		cr, err := clusterConnection.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), expected.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("got an error trying to get a cluster role %s: %v", expected.Name, err)
+		}
+		// verify that the expected policy rules are set on each role
+		assertGivenRoleHasExpectedRules(t, cr, expected.Rules)
+	}
+}
+
+// TestCreateClusterRolesCreateAnAlreadyExistingRole tests that an existing cluster role will be properly updated
+// on a call to CreateClusterRoles.
+// GIVEN a cluster which has an expected cluster role with no policy rules
+//  WHEN I call CreateClusterRoles
+//  THEN the expected cluster role should still exist
+//   AND the cluster role should have been updated with the expected set of policy rules
+func TestCreateClusterRolesCreateAnAlreadyExistingRole(t *testing.T) {
+	assert := assert.New(t)
+
+	modelBindingPair := testutil.GetModelBindingPair()
+	clusterConnections := testutil.GetManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster1"]
+	serviceAccountName := util.GetServiceAccountNameForSystem()
+
+	// create a cluster role with the service account name but NO rules
+	// the expectation is that the call to CreateClusterRoles should update the cluster role with the missing rules
+	cr := &v1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   serviceAccountName,
+			Labels: util.GetManagedLabelsNoBinding("cluster1"),
+		},
+	}
+	_, err := clusterConnection.KubeClient.RbacV1().ClusterRoles().Create(context.TODO(), cr, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("got an error trying to create a cluster role: %v", err)
+	}
+
+	err = CreateClusterRoles(modelBindingPair, clusterConnections)
+	if err != nil {
+		t.Fatalf("got an error from CreateClusterRoles: %v", err)
+	}
+	// verify that a cluster role with the service account name exists
+	cr, err = clusterConnection.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("got an error trying to  get a cluster role: %v", err)
+	}
+	// verify that the expected properties and policy rules are set on the new cluster role
+	assert.Equal(serviceAccountName, cr.Name, "the name of the cluster role should be %s", serviceAccountName)
+	assertGivenRoleHasExpectedRules(t, cr, policyRules)
+}
+
+// TestDeleteClusterRoles tests that cluster roles are deleted when DeleteClusterRoles is called.
+// CASE 1: bindingLabel = false
+//  GIVEN a cluster which has a cluster role that should be cleaned up by a call to DeleteClusterRoles (based on labels)
+//   WHEN I call DeleteClusterRoles with the arg bindingLabel = false
+//   THEN the cluster role matched by "k8s-app" and "verrazzano.cluster" labels should be deleted
+// CASE 2: bindingLabel = true
+//  GIVEN a cluster which has a cluster role that should be cleaned up by a call to DeleteClusterRoles (based on labels)
+//   WHEN I call DeleteClusterRoles with the arg bindingLabel = true
+//   THEN the cluster role matched by "verrazzano.binding" label should be deleted
+func TestDeleteClusterRoles(t *testing.T) {
+	type args struct {
+		mbPair                             *types.ModelBindingPair
+		availableManagedClusterConnections map[string]*util.ManagedClusterConnection
+		bindingLabel                       bool
+		labels                             map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			// test with bindingLabel arg set to false and matching cluster role labels
+			name: "BindingLabelFalse",
+			args: args{
+				mbPair:                             testutil.GetModelBindingPair(),
+				availableManagedClusterConnections: testutil.GetManagedClusterConnections(),
+				bindingLabel:                       false,
+				labels: map[string]string{
+					"k8s-app":            "verrazzano.io",
+					"verrazzano.cluster": "cluster1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// test with bindingLabel arg set to true and matching cluster role labels
+			name: "BindingLabelTrue",
+			args: args{
+				mbPair:                             testutil.GetModelBindingPair(),
+				availableManagedClusterConnections: testutil.GetManagedClusterConnections(),
+				bindingLabel:                       true,
+				labels: map[string]string{
+					"verrazzano.binding": "testBinding",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterConnection := tt.args.availableManagedClusterConnections["cluster1"]
+
+			// create a cluster role that should be cleaned up by a call to DeleteClusterRoles (based on labels)
+			cr := v1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "delete-me",
+					Labels: tt.args.labels,
+				},
+			}
+			_, err := clusterConnection.KubeClient.RbacV1().ClusterRoles().Create(context.TODO(), &cr, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("got an error trying to create a cluster role: %v", err)
+			}
+
+			// create a cluster role that should NOT be cleaned up by a call to DeleteClusterRoles (based on labels)
+			cr = v1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dont-delete-me",
+				},
+			}
+			_, err = clusterConnection.KubeClient.RbacV1().ClusterRoles().Create(context.TODO(), &cr, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("got an error trying to create a cluster role: %v", err)
+			}
+
+			if err := DeleteClusterRoles(tt.args.mbPair, tt.args.availableManagedClusterConnections, tt.args.bindingLabel); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteClusterRoles() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// the expectation is that this cluster role should be deleted after the call to DeleteClusterRoles
+			_, err = clusterConnection.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), "delete-me", metav1.GetOptions{})
+			if err == nil {
+				t.Fatal("expected cluster role 'delete-me' to be deleted")
+			}
+
+			// the expectation is that this cluster role should NOT be deleted after the call to DeleteClusterRoles
+			_, err = clusterConnection.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), "dont-delete-me", metav1.GetOptions{})
+			if err != nil {
+				t.Fatal("expected cluster role 'dont-delete-me' to be still exist")
+			}
+		})
+	}
+}
+
+// assertGivenRoleHasExpectedRules asserts that the given cluster role has the exact set of expected policy rules
+func assertGivenRoleHasExpectedRules(t *testing.T, cr *v1.ClusterRole, expectedRules []rbacv1.PolicyRule) {
+	assert := assert.New(t)
+
+	// assert that the given role has the exact set of expected rules
+	assert.Len(cr.Rules, len(expectedRules), "the given role has does not match the expected policy rules")
+	for _, expected := range expectedRules {
+		matched := false
+		for _, rule := range cr.Rules {
+			matched = reflect.DeepEqual(expected.APIGroups, rule.APIGroups) &&
+				reflect.DeepEqual(expected.Resources, rule.Resources) &&
+				reflect.DeepEqual(expected.Verbs, rule.Verbs)
+			if matched {
+				break
+			}
+		}
+		if !matched {
+			t.Fatalf("can't match the expected policy rule %v in the given cluster role %v", expected, cr)
+		}
+	}
+}

--- a/pkg/testutil/fakes.go
+++ b/pkg/testutil/fakes.go
@@ -14,6 +14,7 @@ import (
 	istioClientset "github.com/verrazzano/verrazzano-crd-generator/pkg/clientistio/clientset/versioned"
 	istioLister "github.com/verrazzano/verrazzano-crd-generator/pkg/clientistio/listers/networking.istio.io/v1alpha3"
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -459,6 +460,33 @@ func (s simpleServiceNamespaceLister) List(selector labels.Selector) (ret []*v1.
 // retrieves the Service for a given namespace and name
 func (s simpleServiceNamespaceLister) Get(name string) (*v1.Service, error) {
 	return s.kubeClient.CoreV1().Services(s.namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// simple ClusterRoleLister implementation
+type simpleClusterRoleLister struct {
+	kubeClient kubernetes.Interface
+}
+
+// List lists all the ClusterRoles.
+func (s *simpleClusterRoleLister) List(selector labels.Selector) (ret []*rbacv1.ClusterRole, err error) {
+	var clusterRoles []*rbacv1.ClusterRole
+
+	list, err := s.kubeClient.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range list.Items {
+		clusterRole := list.Items[i]
+		if selector.Matches(labels.Set(clusterRole.Labels)) {
+			clusterRoles = append(clusterRoles, &clusterRole)
+		}
+	}
+	return clusterRoles, nil
+}
+
+// Get retrieves the ClusterRole for a given name.
+func (s *simpleClusterRoleLister) Get(name string) (*rbacv1.ClusterRole, error) {
+	return s.kubeClient.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
 }
 
 // InvokeHTTPHandler sets up a HTTP handler

--- a/pkg/testutil/fakes_test.go
+++ b/pkg/testutil/fakes_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/verrazzano/verrazzano-operator/pkg/util"
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/selection"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -388,6 +390,86 @@ func TestSimpleServiceLister(t *testing.T) {
 	}
 	assert.Equal(t, "test-service", service.Name)
 	assert.Equal(t, "test", service.Namespace)
+}
+
+// TestSimpleClusterRoleLister tests the functionality of simpleClusterRoleLister
+// GIVEN a cluster which has no existing cluster roles
+//  WHEN I create two cluster roles and a simpleClusterRoleLister
+//  THEN the lister should list exactly two cluster roles given an everything selector
+//   AND the lister should list exactly one specific cluster role given a label selector
+//   AND the lister should get a specific cluster role when requested by name
+func TestSimpleClusterRoleLister(t *testing.T) {
+	// create a map of empty test cluster connections that use fakes
+	clusterConnections := GetManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster1"]
+
+	// add some cluster roles through the fake client set on the test cluster
+	cr := v1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			Labels: map[string]string{
+				"label1": "foo",
+			},
+		},
+	}
+	_, err := clusterConnection.KubeClient.RbacV1().ClusterRoles().Create(context.TODO(), &cr, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("got an error trying to a create cluster role: %v", err)
+	}
+
+	cr = v1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test2",
+		},
+	}
+	_, err = clusterConnection.KubeClient.RbacV1().ClusterRoles().Create(context.TODO(), &cr, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("got an error trying to create cluster role: %v", err)
+	}
+
+	// create a simpleClusterRoleLister using the fake client set from the test cluster
+	l := simpleClusterRoleLister{
+		clusterConnection.KubeClient,
+	}
+
+	// list all the cluster roles through the lister
+	s := labels.Everything()
+	clusterRoles, err := l.List(s)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("got an error trying to list the cluster roles: %v", err))
+	}
+	assert.Len(t, clusterRoles, 2, "expected 2 cluster roles in the list")
+	expectedRoleSet := map[string]struct{}{"test": {}, "test2": {}}
+	for _, clusterRole := range clusterRoles {
+		delete(expectedRoleSet, clusterRole.Name)
+	}
+	assert.Len(t, expectedRoleSet, 0, "not all of the expected roles were returned: %v", expectedRoleSet)
+
+	// list cluster roles through the lister with a label selector
+	requirement, err := labels.NewRequirement("label1", selection.Equals, []string{"foo"})
+	if err != nil {
+		t.Fatal(fmt.Sprintf("got an error trying to create a requirement: %v", err))
+	}
+	s = labels.NewSelector().Add(*requirement)
+	clusterRoles, err = l.List(s)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("got an error trying to list the cluster roles: %v", err))
+	}
+	assert.Len(t, clusterRoles, 1, "expected 1 cluster role in the list")
+	assert.Equal(t, "test", clusterRoles[0].Name, "expected the cluster to be named test")
+
+	// get specific cluster roles through the lister
+	clusterRole, err := l.Get("test")
+	if err != nil {
+		t.Fatal(fmt.Sprintf("got an error trying to get a cluster role: %v", err))
+	}
+	assert.Equal(t, "test", clusterRole.Name, "expected the cluster to be named test")
+
+	clusterRole, err = l.Get("test2")
+	if err != nil {
+		t.Fatal(fmt.Sprintf("got an error trying to get a cluster role: %v", err))
+	}
+	assert.Equal(t, "test2", clusterRole.Name, "expected the cluster to be named test")
 }
 
 func createConfigMap(t *testing.T, name string, clusterConnection *util.ManagedClusterConnection) {

--- a/pkg/testutil/testdata.go
+++ b/pkg/testutil/testdata.go
@@ -56,6 +56,10 @@ func getManagedClusterConnection(clusterName string) *util.ManagedClusterConnect
 		kubeClient: clusterConnection.KubeClient,
 	}
 
+	clusterConnection.ClusterRoleLister = &simpleClusterRoleLister{
+		kubeClient: clusterConnection.KubeClient,
+	}
+
 	clusterConnection.SecretLister = &simpleSecretLister{
 		kubeClient: clusterConnection.KubeClient,
 	}


### PR DESCRIPTION
Add unit tests for clusterroles.go.

Changes previously approved in PR https://github.com/verrazzano/verrazzano-operator/pull/145.
Needed to move the changes to this new branch to get around a messed up code coverage check that was blocking the other branch.

Acceptance tests with operator changes in this PR:
https://build.verrazzano.io/blue/organizations/jenkins/verrazzano/detail/tbeerbower%2Ftest-VZ-1337-2/1/pipeline