### PR TITLE
Make API CORS header specific to console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ docker-clean:
 	rm -rf ${DIST_DIR}
 
 .PHONY: build
-build: go-mod check
+build: go-mod
 	docker build --pull \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} .
 

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -4823,7 +4823,7 @@ github.com/docker/libtrust
 Code and documentation copyright 2014 Docker, inc. Code released under the Apache 2.0 license.
 
 -------- Dependency
-github.com/docker/spdystream [uses Creative Commons license for doc, included at the end of this file]
+github.com/docker/spdystream [uses Creative Commons license for doc - see CC license at end of file]
 -------- Copyrights
    Copyright 2014-2015 Docker, Inc.
 Copyright © 2014-2015 Docker, Inc. All rights reserved, except as follows. Code is released under the Apache 2.0 license. The README.md file, and files in the "docs" folder are licensed under the Creative Commons Attribution 4.0 International License under the terms and conditions set forth in the file "LICENSE.docs". You may obtain a duplicate copy of the same license, titled CC-BY-SA-4.0, at http://creativecommons.org/licenses/by/4.0/.
@@ -8867,7 +8867,6 @@ golang.org/x/mod
 Copyright (c) 2009 The Go Authors. All rights reserved.
 // Copyright 2019 The Go Authors. All rights reserved.
 // Copyright 2018 The Go Authors. All rights reserved.
-// Copyright 2020 The Go Authors. All rights reserved.
 -------- Patents
 Additional IP Rights Grant (Patents)
 
@@ -9544,7 +9543,7 @@ github.com/armon/circbuf
 Copyright (c) 2013 Armon Dadgar
 
 -------- Dependency
-github.com/armon/go-metrics [uses Creative Commons license for doc, included at the end of this file]
+github.com/armon/go-metrics [uses Creative Commons license for doc - see CC license at end of file]
 -------- Copyrights
 Copyright (c) 2013 Armon Dadgar
 
@@ -9772,11 +9771,6 @@ Copyright (c) 2016 Matthias Kadenbach
 Copyright (c) 2018 Dale Hui
 
 -------- Dependency
-github.com/gordonklaus/ineffassign
--------- Copyrights
-Copyright (c) 2016 Gordon Klaus and contributors
-
--------- Dependency
 github.com/gosuri/uitable
 -------- Copyrights
 Copyright (c) 2015, Greg Osuri
@@ -9944,7 +9938,6 @@ Portions Copyright (C) 2011 Blake Mizerany
 -------- Dependency
 github.com/lightstep/lightstep-tracer-common/golang/gogo
 -------- Copyrights
-Copyright (c) 2015-2019 LightStep
 
 -------- Dependency
 github.com/lightstep/lightstep-tracer-go
@@ -10493,7 +10486,6 @@ github.com/gobuffalo/packd
 github.com/gobuffalo/packr/v2
 github.com/gobwas/glob
 github.com/golang-migrate/migrate/v4
-github.com/gordonklaus/ineffassign
 github.com/gosuri/uitable
 github.com/hailocab/go-hostpool
 github.com/hashicorp/go-hclog
@@ -11200,14 +11192,8 @@ github.com/go-bindata/go-bindata/v3
 -------- Copyrights
 	return fmt.Sprintf("%s %d.%d.%s (Go runtime %s).\nCopyright (c) 2010-2013, Jim Teeuwen.",
 
--------- Dependency
-github.com/jteeuwen/go-bindata
--------- Copyrights
-	return fmt.Sprintf("%s %d.%d.%s (Go runtime %s).\nCopyright (c) 2010-2013, Jim Teeuwen.",
-
 ======== Dependencies Summary
 github.com/go-bindata/go-bindata/v3
-github.com/jteeuwen/go-bindata
 
 ======== License used by Dependencies
 This work is subject to the CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
@@ -11788,4 +11774,4 @@ Creative Commons may be contacted at creativecommons.org.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: ab132dd5a710147bd774529cf9e839c4
+License file based on go.mod with md5 sum: 9a6bacedd1b606f12ade631e5167fc9d

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -8867,6 +8867,7 @@ golang.org/x/mod
 Copyright (c) 2009 The Go Authors. All rights reserved.
 // Copyright 2019 The Go Authors. All rights reserved.
 // Copyright 2018 The Go Authors. All rights reserved.
+// Copyright 2020 The Go Authors. All rights reserved.
 -------- Patents
 Additional IP Rights Grant (Patents)
 
@@ -9771,6 +9772,11 @@ Copyright (c) 2016 Matthias Kadenbach
 Copyright (c) 2018 Dale Hui
 
 -------- Dependency
+github.com/gordonklaus/ineffassign
+-------- Copyrights
+Copyright (c) 2016 Gordon Klaus and contributors
+
+-------- Dependency
 github.com/gosuri/uitable
 -------- Copyrights
 Copyright (c) 2015, Greg Osuri
@@ -10487,6 +10493,7 @@ github.com/gobuffalo/packd
 github.com/gobuffalo/packr/v2
 github.com/gobwas/glob
 github.com/golang-migrate/migrate/v4
+github.com/gordonklaus/ineffassign
 github.com/gosuri/uitable
 github.com/hailocab/go-hostpool
 github.com/hashicorp/go-hclog
@@ -11781,4 +11788,4 @@ Creative Commons may be contacted at creativecommons.org.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: 9a971baf7f3ef52e8bf8771cc8b33ae4
+License file based on go.mod with md5 sum: ab132dd5a710147bd774529cf9e839c4

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/verrazzano/verrazzano-wko-operator v0.0.12
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/tools v0.0.0-20200929171317-ffa3839b1b15 // indirect
+	golang.org/x/tools v0.0.0-20200929210017-bce87a7896cc // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.2.8
 	istio.io/api v0.0.0-20200629210345-933b83065c19

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/verrazzano/verrazzano-operator
 require (
 	github.com/Jeffail/gabs/v2 v2.3.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/gordonklaus/ineffassign v0.0.0-20200809085317-e36bfde3bb78 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
@@ -15,6 +16,8 @@ require (
 	github.com/verrazzano/verrazzano-monitoring-operator v0.0.24
 	github.com/verrazzano/verrazzano-wko-operator v0.0.12
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/tools v0.0.0-20200929171317-ffa3839b1b15 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.2.8
 	istio.io/api v0.0.0-20200629210345-933b83065c19

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,8 @@ module github.com/verrazzano/verrazzano-operator
 require (
 	github.com/Jeffail/gabs/v2 v2.3.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/gordonklaus/ineffassign v0.0.0-20200809085317-e36bfde3bb78 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/go-retryablehttp v0.6.6
-	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/kylelemons/godebug v1.1.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
@@ -16,8 +14,8 @@ require (
 	github.com/verrazzano/verrazzano-monitoring-operator v0.0.24
 	github.com/verrazzano/verrazzano-wko-operator v0.0.12
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/tools v0.0.0-20200929210017-bce87a7896cc // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.2.8
 	istio.io/api v0.0.0-20200629210345-933b83065c19

--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,8 @@ github.com/gophercloud/gophercloud v0.3.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gordonklaus/ineffassign v0.0.0-20200809085317-e36bfde3bb78 h1:U/zHjaVG/sECz5xhnh7kPH+Fv/maPbhZPcaTquo5sPg=
+github.com/gordonklaus/ineffassign v0.0.0-20200809085317-e36bfde3bb78/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -813,6 +815,7 @@ github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSf
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
@@ -866,12 +869,17 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f h1:J5lckAjkw6qYlOZNj90mLYNTEKDvWeuc1yieZ8qUzUE=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -911,6 +919,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -923,6 +933,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1029,10 +1040,15 @@ golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b h1:AFZdJUT7jJYXQEC29hYH/WZkoV7+KhwxQGmdZ19yYoY=
 golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200929171317-ffa3839b1b15 h1:s33SBQ1OlHXEdNuwJN/Dawg8xZSRx3p8fHEa0ELe41s=
+golang.org/x/tools v0.0.0-20200929171317-ffa3839b1b15/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gomodules.xyz/jsonpatch/v3 v3.0.1/go.mod h1:CBhndykehEwTOlEfnsfJwvkFQbSN8YZFr9M+cIHAJto=
 gomodules.xyz/orderedmap v0.1.0/go.mod h1:g9/TPUCm1t2gwD3j3zfV8uylyYhVdCNSi+xCEIu7yTU=

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,7 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7RHGAyAK3EP2EsNk=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
@@ -385,6 +386,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -400,8 +402,6 @@ github.com/gophercloud/gophercloud v0.3.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gordonklaus/ineffassign v0.0.0-20200809085317-e36bfde3bb78 h1:U/zHjaVG/sECz5xhnh7kPH+Fv/maPbhZPcaTquo5sPg=
-github.com/gordonklaus/ineffassign v0.0.0-20200809085317-e36bfde3bb78/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -434,6 +434,7 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -465,6 +466,7 @@ github.com/hashicorp/memberlist v0.1.4/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/memberlist v0.1.5/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.8.5/go.mod h1:UpNcs7fFbpKIyZaUuSW6EPiH+eZC7OuyFD+wc1oal+k=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
@@ -498,8 +500,6 @@ github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/jsonnet-bundler/jsonnet-bundler v0.3.1/go.mod h1:/by7P/OoohkI3q4CgSFqcoFsVY+IaNbzOVDknEsKDeU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -510,9 +510,11 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kshvakov/clickhouse v1.3.5/go.mod h1:DMzX7FxRymoNkVgizH0DWAL8Cur7wHLgx3MUnGwJqpE=
 github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
@@ -611,6 +613,7 @@ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -619,6 +622,7 @@ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -815,7 +819,6 @@ github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSf
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
@@ -871,15 +874,11 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f h1:J5lckAjkw6qYlOZNj90mLYNTEKDvWeuc1yieZ8qUzUE=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
-golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -933,7 +932,6 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1040,16 +1038,12 @@ golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b h1:AFZdJUT7jJYXQEC29hYH/WZkoV7+KhwxQGmdZ19yYoY=
 golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200929171317-ffa3839b1b15 h1:s33SBQ1OlHXEdNuwJN/Dawg8xZSRx3p8fHEa0ELe41s=
-golang.org/x/tools v0.0.0-20200929171317-ffa3839b1b15/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
-golang.org/x/tools v0.0.0-20200929210017-bce87a7896cc h1:zvv75kM708Up/btORydXz1Uotkl+HIxcGI3gr+otDZM=
-golang.org/x/tools v0.0.0-20200929210017-bce87a7896cc/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gomodules.xyz/jsonpatch/v3 v3.0.1/go.mod h1:CBhndykehEwTOlEfnsfJwvkFQbSN8YZFr9M+cIHAJto=
@@ -1121,9 +1115,11 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/fsnotify/fsnotify.v1 v1.4.7/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
@@ -1140,6 +1136,7 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.1.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -1045,6 +1045,8 @@ golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b h1:AFZdJUT7jJYXQEC29hYH/WZ
 golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200929171317-ffa3839b1b15 h1:s33SBQ1OlHXEdNuwJN/Dawg8xZSRx3p8fHEa0ELe41s=
 golang.org/x/tools v0.0.0-20200929171317-ffa3839b1b15/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20200929210017-bce87a7896cc h1:zvv75kM708Up/btORydXz1Uotkl+HIxcGI3gr+otDZM=
+golang.org/x/tools v0.0.0-20200929210017-bce87a7896cc/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/api/instance/instance.go
+++ b/pkg/api/instance/instance.go
@@ -81,7 +81,7 @@ func getVersion() string {
 	return "0.1.0"
 }
 
-// Derive the URL from the verrazzano URI by replacing the 'api' segment
+// Derive the URL from the verrazzano URI by prefixing with the given URL segment
 func deriveURL(s string) string {
 	if len(strings.TrimSpace(verrazzanoURI)) > 0 {
 		return "https://" + s + "." + verrazzanoURI

--- a/pkg/api/instance/instance.go
+++ b/pkg/api/instance/instance.go
@@ -85,9 +85,8 @@ func getVersion() string {
 func deriveURL(s string) string {
 	if len(strings.TrimSpace(verrazzanoURI)) > 0 {
 		return "https://" + s + "." + verrazzanoURI
-	} else {
-		return ""
 	}
+	return ""
 }
 
 // GetVerrazzanoName returns the environment name portion of the verrazzanoUri

--- a/pkg/api/instance/instance.go
+++ b/pkg/api/instance/instance.go
@@ -83,7 +83,11 @@ func getVersion() string {
 
 // Derive the URL from the verrazzano URI by replacing the 'api' segment
 func deriveURL(s string) string {
-	return "https://" + s + "." + verrazzanoURI
+	if len(strings.TrimSpace(verrazzanoURI)) > 0 {
+		return "https://" + s + "." + verrazzanoURI
+	} else {
+		return ""
+	}
 }
 
 // GetVerrazzanoName returns the environment name portion of the verrazzanoUri
@@ -118,4 +122,9 @@ func GetPrometheusURL() string {
 // GetElasticURL returns Elasticsearch URL
 func GetElasticURL() string {
 	return deriveURL("elasticsearch.vmi.system")
+}
+
+// GetConsoleURL returns the Verrazzano Console URL
+func GetConsoleURL() string {
+	return deriveURL("console")
 }

--- a/pkg/api/instance/instance_test.go
+++ b/pkg/api/instance/instance_test.go
@@ -14,42 +14,97 @@ const urlTemp = "https://%v.%v"
 
 const vzURI = "abc.v8o.example.com"
 
-// Test KeyCloak Url
-func TestGetKeyCloakUrl(t *testing.T) {
-	SetVerrazzanoURI(vzURI)
-	keycloakURL := fmt.Sprintf(urlTemp, "keycloak", vzURI)
-	assert.Equal(t, keycloakURL, GetKeyCloakURL(), "Expected KeyCloakUrl")
-
-	vzURI2 := "xyz.v8o.example.com"
-	SetVerrazzanoURI(vzURI2)
-	keycloakURL = fmt.Sprintf(urlTemp, "keycloak", vzURI2)
-	assert.Equal(t, keycloakURL, GetKeyCloakURL(), "Expected KeyCloakUrl")
+type uriTest struct {
+	name           string
+	expectedPrefix string
+	testChangedURI bool
+	verrazzanoURI  string
 }
 
-// Test Kinana Url
+// Test KeyCloak Url
+func TestGetKeyCloakUrl(t *testing.T) {
+	var tests = [...]uriTest{
+		{"With Verrazzano URI set", "keycloak", true, vzURI},
+		{"Without Verrazzano URI set", "", false, ""},
+	}
+	for _, tt := range tests {
+		runURLTestWithExpectedPrefix(t, tt, GetKeyCloakURL, tt.expectedPrefix)
+	}
+}
+
+// Test Kibana Url
 func TestGetKibanaUrl(t *testing.T) {
-	SetVerrazzanoURI(vzURI)
-	expectedURL := fmt.Sprintf(urlTemp, "kibana.vmi.system", vzURI)
-	assert.Equal(t, expectedURL, GetKibanaURL(), "Invalid Kibana Url")
+	var tests = [...]uriTest{
+		{"With Verrazzano URI set", "kibana.vmi.system", true, vzURI},
+		{"Without Verrazzano URI set", "", false, ""},
+	}
+	for _, tt := range tests {
+		runURLTestWithExpectedPrefix(t, tt, GetKibanaURL, tt.expectedPrefix)
+	}
 }
 
 // Test Grafana Url
 func TestGetGrafanaUrl(t *testing.T) {
-	SetVerrazzanoURI(vzURI)
-	expectedURL := fmt.Sprintf(urlTemp, "grafana.vmi.system", vzURI)
-	assert.Equal(t, expectedURL, GetGrafanaURL(), "Invalid Grafana Url")
+	var tests = [...]uriTest{
+		{"With Verrazzano URI set", "grafana.vmi.system", true, vzURI},
+		{"Without Verrazzano URI set", "", false, ""},
+	}
+	for _, tt := range tests {
+		runURLTestWithExpectedPrefix(t, tt, GetGrafanaURL, tt.expectedPrefix)
+	}
 }
 
 // Test Prometheus Url
 func TestGetPrometheusUrl(t *testing.T) {
-	SetVerrazzanoURI(vzURI)
-	expectedURL := fmt.Sprintf(urlTemp, "prometheus.vmi.system", vzURI)
-	assert.Equal(t, expectedURL, GetPrometheusURL(), "Invalid Prometheus Url")
+	var tests = [...]uriTest{
+		{"With Verrazzano URI set", "prometheus.vmi.system", true, vzURI},
+		{"Without Verrazzano URI set", "", false, ""},
+	}
+	for _, tt := range tests {
+		runURLTestWithExpectedPrefix(t, tt, GetPrometheusURL, tt.expectedPrefix)
+	}
 }
 
 // Test Elastic Search Url
 func TestGetElasticUrl(t *testing.T) {
-	SetVerrazzanoURI(vzURI)
-	expectedURL := fmt.Sprintf(urlTemp, "elasticsearch.vmi.system", vzURI)
-	assert.Equal(t, expectedURL, GetElasticURL(), "Invalid Elastic Url")
+	var tests = [...]uriTest{
+		{"With Verrazzano URI set", "elasticsearch.vmi.system", true, vzURI},
+		{"Without Verrazzano URI set", "", false, ""},
+	}
+	for _, tt := range tests {
+		runURLTestWithExpectedPrefix(t, tt, GetElasticURL, tt.expectedPrefix)
+	}
+}
+
+// Test Console Url
+func TestGetConsoleURL(t *testing.T) {
+	var tests = [...]uriTest{
+		{"With Verrazzano URI set", "console", true, vzURI},
+		{"Without Verrazzano URI set", "", false, ""},
+	}
+	for _, tt := range tests {
+		runURLTestWithExpectedPrefix(t, tt, GetConsoleURL, tt.expectedPrefix)
+	}
+}
+
+func runURLTestWithExpectedPrefix(t *testing.T, tt uriTest, methodUnderTest func() string, expectedURLPrefix string) {
+	//GIVEN the verrazzano URI is set
+	SetVerrazzanoURI(tt.verrazzanoURI)
+	expectedURL := fmt.Sprintf(urlTemp, expectedURLPrefix, vzURI)
+	if expectedURLPrefix == "" {
+		expectedURL = ""
+	}
+
+	//WHEN methodUnderTest is called, THEN assert the URL value is as expected
+	assert.Equal(t, expectedURL, methodUnderTest(), "URL not as expected")
+
+	if tt.testChangedURI {
+		vzURI2 := fmt.Sprintf("changed.%v", tt.verrazzanoURI)
+		//GIVEN the verrazzano URI is changed
+		SetVerrazzanoURI(vzURI2)
+		expectedURL = fmt.Sprintf(urlTemp, expectedURLPrefix, vzURI2)
+
+		//WHEN methodUnderTest is called, THEN assert the value changes as expected
+		assert.Equal(t, expectedURL, methodUnderTest(), "URL not as expected after changing Verrazzano URI")
+	}
 }

--- a/pkg/api/instance/instance_test.go
+++ b/pkg/api/instance/instance_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const urlTemp = "https://%v.%v"
+const urlTemplate = "https://%v.%v"
 
 const vzURI = "abc.v8o.example.com"
 
@@ -90,7 +90,7 @@ func TestGetConsoleURL(t *testing.T) {
 func runURLTestWithExpectedPrefix(t *testing.T, tt uriTest, methodUnderTest func() string, expectedURLPrefix string) {
 	//GIVEN the verrazzano URI is set
 	SetVerrazzanoURI(tt.verrazzanoURI)
-	expectedURL := fmt.Sprintf(urlTemp, expectedURLPrefix, vzURI)
+	expectedURL := fmt.Sprintf(urlTemplate, expectedURLPrefix, vzURI)
 	if expectedURLPrefix == "" {
 		expectedURL = ""
 	}
@@ -102,7 +102,7 @@ func runURLTestWithExpectedPrefix(t *testing.T, tt uriTest, methodUnderTest func
 		vzURI2 := fmt.Sprintf("changed.%v", tt.verrazzanoURI)
 		//GIVEN the verrazzano URI is changed
 		SetVerrazzanoURI(vzURI2)
-		expectedURL = fmt.Sprintf(urlTemp, expectedURLPrefix, vzURI2)
+		expectedURL = fmt.Sprintf(urlTemplate, expectedURLPrefix, vzURI2)
 
 		//WHEN methodUnderTest is called, THEN assert the value changes as expected
 		assert.Equal(t, expectedURL, methodUnderTest(), "URL not as expected after changing Verrazzano URI")

--- a/pkg/util/apiserver/cors.go
+++ b/pkg/util/apiserver/cors.go
@@ -32,7 +32,6 @@ func getAllowedOrigins() string {
 	additionalOrigins := util.GetAccessControlAllowOrigins()
 	if additionalOrigins != "" {
 		return fmt.Sprintf("%s, %s", consoleURL, additionalOrigins)
-	} else {
-		return consoleURL
 	}
+	return consoleURL
 }

--- a/pkg/util/apiserver/cors.go
+++ b/pkg/util/apiserver/cors.go
@@ -5,7 +5,6 @@ package apiserver
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/verrazzano/verrazzano-operator/pkg/util"
 
@@ -29,17 +28,13 @@ func SetupOptionsResponse(w *http.ResponseWriter, req *http.Request) {
 	(*w).Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 }
 
+// getAllowedOrigin returns the value to be used for the Access-Control-Allow-Origin response header
+// based on whether or not an additional allowed origin is set
 func getAllowedOrigin(origin string) string {
 	consoleURL := instance.GetConsoleURL()
-	additionalOrigins := util.GetAccessControlAllowOrigins()
-	var allOrigins []string = []string{consoleURL}
-	if additionalOrigins != "" {
-		allOrigins = append(allOrigins, strings.Split(additionalOrigins, ", ")...)
-	}
-	for _, allowedOrigin := range allOrigins {
-		if strings.TrimSpace(allowedOrigin) == strings.TrimSpace(origin) {
-			return origin
-		}
+	additionalOrigin := util.GetAccessControlAllowOrigin()
+	if consoleURL == origin || additionalOrigin == origin {
+		return origin
 	}
 	return ""
 }

--- a/pkg/util/apiserver/cors.go
+++ b/pkg/util/apiserver/cors.go
@@ -3,11 +3,15 @@
 
 package apiserver
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/verrazzano/verrazzano-operator/pkg/api/instance"
+)
 
 // EnableCors adds headers necessary for the browser running the UI to be able to call the API server
 func EnableCors(w *http.ResponseWriter) {
-	(*w).Header().Set("Access-Control-Allow-Origin", "*")
+	(*w).Header().Set("Access-Control-Allow-Origin", instance.GetConsoleURL())
 	// The web UI expects to be able to see X-Total-Count, which is uses for paging result sets
 	(*w).Header().Set("Access-Control-Expose-Headers", "X-Total-Count")
 }
@@ -15,7 +19,7 @@ func EnableCors(w *http.ResponseWriter) {
 // SetupOptionsResponse creates the headers that are needed for a HTTP OPTIONS request
 // The web UI makes an OPTIONS request before each GET/POST/etc.
 func SetupOptionsResponse(w *http.ResponseWriter, req *http.Request) {
-	(*w).Header().Set("Access-Control-Allow-Origin", "*")
+	(*w).Header().Set("Access-Control-Allow-Origin", instance.GetConsoleURL())
 	(*w).Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
 	(*w).Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 }

--- a/pkg/util/apiserver/cors.go
+++ b/pkg/util/apiserver/cors.go
@@ -4,14 +4,17 @@
 package apiserver
 
 import (
+	"fmt"
 	"net/http"
+
+	"github.com/verrazzano/verrazzano-operator/pkg/util"
 
 	"github.com/verrazzano/verrazzano-operator/pkg/api/instance"
 )
 
 // EnableCors adds headers necessary for the browser running the UI to be able to call the API server
 func EnableCors(w *http.ResponseWriter) {
-	(*w).Header().Set("Access-Control-Allow-Origin", instance.GetConsoleURL())
+	(*w).Header().Set("Access-Control-Allow-Origin", getAllowedOrigins())
 	// The web UI expects to be able to see X-Total-Count, which is uses for paging result sets
 	(*w).Header().Set("Access-Control-Expose-Headers", "X-Total-Count")
 }
@@ -19,7 +22,17 @@ func EnableCors(w *http.ResponseWriter) {
 // SetupOptionsResponse creates the headers that are needed for a HTTP OPTIONS request
 // The web UI makes an OPTIONS request before each GET/POST/etc.
 func SetupOptionsResponse(w *http.ResponseWriter, req *http.Request) {
-	(*w).Header().Set("Access-Control-Allow-Origin", instance.GetConsoleURL())
+	(*w).Header().Set("Access-Control-Allow-Origin", getAllowedOrigins())
 	(*w).Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
 	(*w).Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+}
+
+func getAllowedOrigins() string {
+	consoleURL := instance.GetConsoleURL()
+	additionalOrigins := util.GetAccessControlAllowOrigins()
+	if additionalOrigins != "" {
+		return fmt.Sprintf("%s, %s", consoleURL, additionalOrigins)
+	} else {
+		return consoleURL
+	}
 }

--- a/pkg/util/apiserver/cors.go
+++ b/pkg/util/apiserver/cors.go
@@ -14,8 +14,8 @@ import (
 
 // EnableCors adds headers necessary for the browser running the UI to be able to call the API server
 func EnableCors(req *http.Request, w *http.ResponseWriter) {
-	referer := req.Header.Get("Referer")
-	(*w).Header().Set("Access-Control-Allow-Origin", getAllowedOrigin(referer))
+	origin := req.Header.Get("Origin")
+	(*w).Header().Set("Access-Control-Allow-Origin", getAllowedOrigin(origin))
 	// The web UI expects to be able to see X-Total-Count, which is uses for paging result sets
 	(*w).Header().Set("Access-Control-Expose-Headers", "X-Total-Count")
 }
@@ -23,22 +23,22 @@ func EnableCors(req *http.Request, w *http.ResponseWriter) {
 // SetupOptionsResponse creates the headers that are needed for a HTTP OPTIONS request
 // The web UI makes an OPTIONS request before each GET/POST/etc.
 func SetupOptionsResponse(w *http.ResponseWriter, req *http.Request) {
-	referer := req.Header.Get("Referer")
-	(*w).Header().Set("Access-Control-Allow-Origin", getAllowedOrigin(referer))
+	origin := req.Header.Get("Origin")
+	(*w).Header().Set("Access-Control-Allow-Origin", getAllowedOrigin(origin))
 	(*w).Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
 	(*w).Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 }
 
-func getAllowedOrigin(referer string) string {
+func getAllowedOrigin(origin string) string {
 	consoleURL := instance.GetConsoleURL()
 	additionalOrigins := util.GetAccessControlAllowOrigins()
 	var allOrigins []string = []string{consoleURL}
 	if additionalOrigins != "" {
 		allOrigins = append(allOrigins, strings.Split(additionalOrigins, ", ")...)
 	}
-	for _, origin := range allOrigins {
-		if strings.TrimSpace(referer) == strings.TrimSpace(origin) {
-			return referer
+	for _, allowedOrigin := range allOrigins {
+		if strings.TrimSpace(allowedOrigin) == strings.TrimSpace(origin) {
+			return origin
 		}
 	}
 	return ""

--- a/pkg/util/apiserver/cors_test.go
+++ b/pkg/util/apiserver/cors_test.go
@@ -46,6 +46,7 @@ func TestEnableCors(t *testing.T) {
 			req, err := http.NewRequest("GET", "http://someUrl", nil)
 			assert.Nil(t, err, "Error creating test request")
 			req.Header.Add("Referer", tt.referer)
+
 			//WHEN EnableCors is called
 			EnableCors(req, &tt.args.writer)
 
@@ -93,7 +94,7 @@ func TestSetupOptionsResponse(t *testing.T) {
 			//WHEN SetupOptionsResponse is called
 			SetupOptionsResponse(&tt.args.writer, req)
 
-			//THEN it returns the expected CORS header values
+			//THEN it writes the expected CORS header values
 			assert.Equal(t, tt.expectedAllowOrigin, tt.args.writer.Header().Get("Access-Control-Allow-Origin"))
 			assert.Equal(t, strings.Join(tt.expectedAllowMethods, ", "), tt.args.writer.Header().Get("Access-Control-Allow-Methods"))
 			assert.Equal(t, strings.Join(tt.expectedAllowHeaders, ", "), tt.args.writer.Header().Get("Access-Control-Allow-Headers"))

--- a/pkg/util/apiserver/cors_test.go
+++ b/pkg/util/apiserver/cors_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/verrazzano/verrazzano-operator/pkg/api/instance"
 )
 
-var allowedHttpMethods = []string{"POST", "GET", "OPTIONS", "PUT", "DELETE"}
+var allowedHTTPMethods = []string{"POST", "GET", "OPTIONS", "PUT", "DELETE"}
 var allowedHeaders = []string{"Accept", "Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization"}
 
 //TestEnableCors tests that the EnableCors method adds the expected Access-Control-Allow-Origin header to the response
@@ -58,8 +58,8 @@ func TestSetupOptionsResponse(t *testing.T) {
 		expectedAllowHeaders []string
 		args                 args
 	}{
-		{"With Verrazzano URI set", "https://console.somesuffix.xip.io", allowedHttpMethods, allowedHeaders, args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
-		{"Without Verrazzano URI set", "", allowedHttpMethods, allowedHeaders, args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
+		{"With Verrazzano URI set", "https://console.somesuffix.xip.io", allowedHTTPMethods, allowedHeaders, args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
+		{"Without Verrazzano URI set", "", allowedHTTPMethods, allowedHeaders, args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/apiserver/cors_test.go
+++ b/pkg/util/apiserver/cors_test.go
@@ -165,9 +165,8 @@ func Test_getAllowedOrigin(t *testing.T) {
 			util.GetEnvFunc = func(key string) string {
 				if key == "ACCESS_CONTROL_ALLOW_ORIGIN" {
 					return tt.additionalOrigin
-				} else {
-					return os.Getenv(key)
 				}
+				return os.Getenv(key)
 			}
 
 			// WHEN getAllowedOrigin is called for a origin value

--- a/pkg/util/apiserver/cors_test.go
+++ b/pkg/util/apiserver/cors_test.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2020, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/verrazzano/verrazzano-operator/pkg/api/instance"
+)
+
+var allowedHttpMethods = []string{"POST", "GET", "OPTIONS", "PUT", "DELETE"}
+var allowedHeaders = []string{"Accept", "Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization"}
+
+//TestEnableCors tests that the EnableCors method adds the expected Access-Control-Allow-Origin header to the response
+func TestEnableCors(t *testing.T) {
+	type args struct {
+		verrazzanoURI string
+		writer        http.ResponseWriter
+	}
+	tests := []struct {
+		name                string
+		expectedAllowOrigin string
+		args                args
+	}{
+		{"With Verrazzano URI set", "https://console.somesuffix.xip.io", args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
+		{"Without Verrazzano URI set", "", args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//GIVEN the Verrazzano URI suffix is set
+			instance.SetVerrazzanoURI(tt.args.verrazzanoURI)
+
+			//WHEN EnableCors is called
+			EnableCors(&tt.args.writer)
+
+			//THEN it returns the expected Access-Control-Allow-Origin header value
+			assert.Equal(t, tt.expectedAllowOrigin, tt.args.writer.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+//TestSetupOptionsResponse tests that the SetupOptionsResponse method adds the expected CORS related headers to the response
+func TestSetupOptionsResponse(t *testing.T) {
+	type args struct {
+		verrazzanoURI string
+		writer        http.ResponseWriter
+	}
+	tests := []struct {
+		name                 string
+		expectedAllowOrigin  string
+		expectedAllowMethods []string
+		expectedAllowHeaders []string
+		args                 args
+	}{
+		{"With Verrazzano URI set", "https://console.somesuffix.xip.io", allowedHttpMethods, allowedHeaders, args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
+		{"Without Verrazzano URI set", "", allowedHttpMethods, allowedHeaders, args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//GIVEN the Verrazzano URI suffix is set
+			instance.SetVerrazzanoURI(tt.args.verrazzanoURI)
+
+			//WHEN SetupOptionsResponse is called
+			SetupOptionsResponse(&tt.args.writer, nil)
+
+			//THEN it returns the expected CORS header values
+			assert.Equal(t, tt.expectedAllowOrigin, tt.args.writer.Header().Get("Access-Control-Allow-Origin"))
+			assert.Equal(t, strings.Join(tt.expectedAllowMethods, ", "), tt.args.writer.Header().Get("Access-Control-Allow-Methods"))
+			assert.Equal(t, strings.Join(tt.expectedAllowHeaders, ", "), tt.args.writer.Header().Get("Access-Control-Allow-Headers"))
+		})
+	}
+}

--- a/pkg/util/apiserver/cors_test.go
+++ b/pkg/util/apiserver/cors_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/verrazzano/verrazzano-operator/pkg/util"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/verrazzano/verrazzano-operator/pkg/api/instance"
@@ -160,7 +162,13 @@ func Test_getAllowedOrigin(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// GIVEN the verrazzano URI suffix and an ACCESS_CONTROL_ALLOW_ORIGINS override env var
 			instance.SetVerrazzanoURI(vzURI)
-			os.Setenv("ACCESS_CONTROL_ALLOW_ORIGIN", tt.additionalOrigin)
+			util.GetEnvFunc = func(key string) string {
+				if key == "ACCESS_CONTROL_ALLOW_ORIGIN" {
+					return tt.additionalOrigin
+				} else {
+					return os.Getenv(key)
+				}
+			}
 
 			// WHEN getAllowedOrigin is called for a origin value
 			actualOrigin := getAllowedOrigin(tt.origin)
@@ -172,7 +180,6 @@ func Test_getAllowedOrigin(t *testing.T) {
 			} else {
 				assert.Empty(t, actualOrigin)
 			}
-			os.Unsetenv("ACCESS_CONTROL_ALLOW_ORIGINS")
 		})
 	}
 }

--- a/pkg/util/apiserver/cors_test.go
+++ b/pkg/util/apiserver/cors_test.go
@@ -27,7 +27,7 @@ func TestEnableCors(t *testing.T) {
 	}
 	tests := []struct {
 		name                string
-		referer             string
+		origin              string
 		expectedAllowOrigin string
 		args                args
 	}{
@@ -36,7 +36,7 @@ func TestEnableCors(t *testing.T) {
 			args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
 		{"Without Verrazzano URI set", "http://localhost",
 			"", args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
-		{"Referer does not match", "http://localhost",
+		{"Origin does not match", "http://localhost",
 			"", args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
 	}
 	for _, tt := range tests {
@@ -45,7 +45,7 @@ func TestEnableCors(t *testing.T) {
 			instance.SetVerrazzanoURI(tt.args.verrazzanoURI)
 			req, err := http.NewRequest("GET", "http://someUrl", nil)
 			assert.Nil(t, err, "Error creating test request")
-			req.Header.Add("Referer", tt.referer)
+			req.Header.Add("origin", tt.origin)
 
 			//WHEN EnableCors is called
 			EnableCors(req, &tt.args.writer)
@@ -64,7 +64,7 @@ func TestSetupOptionsResponse(t *testing.T) {
 	}
 	tests := []struct {
 		name                 string
-		referer              string
+		origin               string
 		expectedAllowOrigin  string
 		expectedAllowMethods []string
 		expectedAllowHeaders []string
@@ -79,7 +79,7 @@ func TestSetupOptionsResponse(t *testing.T) {
 			allowedHTTPMethods, allowedHeaders,
 			args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
 
-		{"Referer does not match", "http://localhost", "",
+		{"Origin does not match", "http://localhost", "",
 			allowedHTTPMethods, allowedHeaders,
 			args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
 	}
@@ -89,7 +89,7 @@ func TestSetupOptionsResponse(t *testing.T) {
 			instance.SetVerrazzanoURI(tt.args.verrazzanoURI)
 			req, err := http.NewRequest("GET", "http://someUrl", nil)
 			assert.Nil(t, err, "Error creating test request")
-			req.Header.Add("Referer", tt.referer)
+			req.Header.Add("Origin", tt.origin)
 
 			//WHEN SetupOptionsResponse is called
 			SetupOptionsResponse(&tt.args.writer, req)
@@ -107,9 +107,9 @@ func Test_getAllowedOrigin(t *testing.T) {
 	defaultExpectedValue := fmt.Sprintf("https://console.%s", vzURI)
 	tests := []struct {
 		name              string
-		referer           string
+		origin            string
 		additionalOrigins []string
-		refererAllowed    bool
+		originAllowed     bool
 	}{
 		{"origin matches default", defaultExpectedValue, []string{}, true},
 		{"origin matches default with additional origin", defaultExpectedValue, []string{"http://localhost:8000"}, true},
@@ -125,13 +125,13 @@ func Test_getAllowedOrigin(t *testing.T) {
 			instance.SetVerrazzanoURI(vzURI)
 			os.Setenv("ACCESS_CONTROL_ALLOW_ORIGINS", strings.Join(tt.additionalOrigins, ", "))
 
-			// WHEN getAllowedOrigin is called for a referer value
-			actualOrigin := getAllowedOrigin(tt.referer)
+			// WHEN getAllowedOrigin is called for a origin value
+			actualOrigin := getAllowedOrigin(tt.origin)
 
-			// THEN, if the referer is allowed, it should be returned in the allowed origin,
+			// THEN, if the origin is allowed, it should be returned in the allowed origin,
 			// otherwise empty string should be returned
-			if tt.refererAllowed {
-				assert.Equal(t, tt.referer, actualOrigin)
+			if tt.originAllowed {
+				assert.Equal(t, tt.origin, actualOrigin)
 			} else {
 				assert.Empty(t, actualOrigin)
 			}

--- a/pkg/util/apiserver/cors_test.go
+++ b/pkg/util/apiserver/cors_test.go
@@ -31,15 +31,25 @@ func TestEnableCors(t *testing.T) {
 		expectedAllowOrigin string
 		args                args
 	}{
-		{"Verrazzano URI is set", "https://console.somesuffix.xip.io",
-			"https://console.somesuffix.xip.io",
-			args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
-		{"Without Verrazzano URI set", "http://localhost",
-			"", args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
-		{"Without Verrazzano URI set and different port Origin", "http://localhost:8000",
-			"", args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
-		{"Origin does not match", "http://localhost",
-			"", args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
+		{name: "Verrazzano URI is set",
+			origin:              "https://console.somesuffix.xip.io",
+			expectedAllowOrigin: "https://console.somesuffix.xip.io",
+			args:                args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
+
+		{name: "Without Verrazzano URI set",
+			origin:              "http://localhost",
+			expectedAllowOrigin: "",
+			args:                args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
+
+		{name: "Without Verrazzano URI set and different port Origin",
+			origin:              "http://localhost:8000",
+			expectedAllowOrigin: "",
+			args:                args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
+
+		{name: "Origin does not match",
+			origin:              "http://localhost",
+			expectedAllowOrigin: "",
+			args:                args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -72,18 +82,26 @@ func TestSetupOptionsResponse(t *testing.T) {
 		expectedAllowHeaders []string
 		args                 args
 	}{
-		{"With Verrazzano URI set", "https://console.somesuffix.xip.io",
-			"https://console.somesuffix.xip.io",
-			allowedHTTPMethods, allowedHeaders,
-			args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
+		{name: "With Verrazzano URI set",
+			origin:               "https://console.somesuffix.xip.io",
+			expectedAllowOrigin:  "https://console.somesuffix.xip.io",
+			expectedAllowMethods: allowedHTTPMethods,
+			expectedAllowHeaders: allowedHeaders,
+			args:                 args{verrazzanoURI: "somesuffix.xip.io", writer: http.ResponseWriter(httptest.NewRecorder())}},
 
-		{"Without Verrazzano URI set", "", "",
-			allowedHTTPMethods, allowedHeaders,
-			args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
+		{name: "Without Verrazzano URI set",
+			origin:               "",
+			expectedAllowOrigin:  "",
+			expectedAllowMethods: allowedHTTPMethods,
+			expectedAllowHeaders: allowedHeaders,
+			args:                 args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
 
-		{"Origin does not match", "http://localhost", "",
-			allowedHTTPMethods, allowedHeaders,
-			args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
+		{name: "Origin does not match",
+			origin:               "http://localhost",
+			expectedAllowOrigin:  "",
+			expectedAllowMethods: allowedHTTPMethods,
+			expectedAllowHeaders: allowedHeaders,
+			args:                 args{verrazzanoURI: "", writer: http.ResponseWriter(httptest.NewRecorder())}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -113,11 +131,30 @@ func Test_getAllowedOrigin(t *testing.T) {
 		additionalOrigin string
 		originAllowed    bool
 	}{
-		{"origin matches default", defaultExpectedValue, "", true},
-		{"origin matches default with additional origin", defaultExpectedValue, "http://localhost:8000", true},
-		{"origin matches additional origin", "http://localhost:8000", "http://localhost:8000", true},
-		{"negative test origin matches none", "http://somethingelse", "http://localhost:8000", false},
-		{"negative test origin does not match default", "http://somethingelse", "", false},
+		{name: "origin matches default",
+			origin:           defaultExpectedValue,
+			additionalOrigin: "",
+			originAllowed:    true},
+
+		{name: "origin matches default with additional origin",
+			origin:           defaultExpectedValue,
+			additionalOrigin: "http://localhost:8000",
+			originAllowed:    true},
+
+		{name: "origin matches additional origin",
+			origin:           "http://localhost:8000",
+			additionalOrigin: "http://localhost:8000",
+			originAllowed:    true},
+
+		{name: "negative test origin matches none",
+			origin:           "http://somethingelse",
+			additionalOrigin: "http://localhost:8000",
+			originAllowed:    false},
+
+		{name: "negative test origin does not match default",
+			origin:           "http://somethingelse",
+			additionalOrigin: "",
+			originAllowed:    false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/apiserver/handlers.go
+++ b/pkg/util/apiserver/handlers.go
@@ -14,7 +14,7 @@ import (
 // or delegate to the actual handler on real requests
 func CORSHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		EnableCors(&w)
+		EnableCors(r, &w)
 		if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
 			// CORS preflight request
 			SetupOptionsResponse(&w, r)

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -140,7 +140,7 @@ func GetElasticsearchMasterNodeReplicas() int32 {
 	return 3
 }
 
-// GetAccessControlAllowOrigins returns the additional allowed origins for API requests - these
+// GetAccessControlAllowOrigin returns the additional allowed origins for API requests - these
 // will be added to the Access-Control-Allow-Origins response header of the API
 func GetAccessControlAllowOrigin() string {
 	return os.Getenv(accessControlAllowOrigin)

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -32,7 +32,7 @@ const grafanaRequestMemory = "GRAFANA_REQUEST_MEMORY"
 const prometheusRequestMemory = "PROMETHEUS_REQUEST_MEMORY"
 const kibanaRequestMemory = "KIBANA_REQUEST_MEMORY"
 const esMasterNodeReplicas = "ES_MASTER_NODE_REPLICAS"
-const accessControlAllowOrigins = "ACCESS_CONTROL_ALLOW_ORIGINS"
+const accessControlAllowOrigin = "ACCESS_CONTROL_ALLOW_ORIGIN"
 
 func getCohMicroImage() string {
 	return os.Getenv(cohMicroImage)
@@ -142,6 +142,6 @@ func GetElasticsearchMasterNodeReplicas() int32 {
 
 // GetAccessControlAllowOrigins returns the additional allowed origins for API requests - these
 // will be added to the Access-Control-Allow-Origins response header of the API
-func GetAccessControlAllowOrigins() string {
-	return os.Getenv(accessControlAllowOrigins)
+func GetAccessControlAllowOrigin() string {
+	return os.Getenv(accessControlAllowOrigin)
 }

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -32,6 +32,7 @@ const grafanaRequestMemory = "GRAFANA_REQUEST_MEMORY"
 const prometheusRequestMemory = "PROMETHEUS_REQUEST_MEMORY"
 const kibanaRequestMemory = "KIBANA_REQUEST_MEMORY"
 const esMasterNodeReplicas = "ES_MASTER_NODE_REPLICAS"
+const accessControlAllowOrigins = "ACCESS_CONTROL_ALLOW_ORIGINS"
 
 func getCohMicroImage() string {
 	return os.Getenv(cohMicroImage)
@@ -137,4 +138,8 @@ func GetElasticsearchMasterNodeReplicas() int32 {
 		}
 	}
 	return 3
+}
+
+func GetAccessControlAllowOrigins() string {
+	return os.Getenv(accessControlAllowOrigins)
 }

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -12,7 +12,7 @@ import (
 
 // This file contains all of the env vars used by the Verrazzano Operator
 
-// Store the GetEnv function in a variable, so that tests can override it
+// GetEnvFunc stores the GetEnv function in a variable, so that tests can override it
 var GetEnvFunc = os.Getenv
 
 // Define the ENV vars

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -140,6 +140,8 @@ func GetElasticsearchMasterNodeReplicas() int32 {
 	return 3
 }
 
+// GetAccessControlAllowOrigins returns the additional allowed origins for API requests - these
+// will be added to the Access-Control-Allow-Origins response header of the API
 func GetAccessControlAllowOrigins() string {
 	return os.Getenv(accessControlAllowOrigins)
 }

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -11,6 +11,10 @@ import (
 )
 
 // This file contains all of the env vars used by the Verrazzano Operator
+
+// Store the GetEnv function in a variable, so that tests can override it
+var GetEnvFunc = os.Getenv
+
 // Define the ENV vars
 
 const cohMicroImage = "COH_MICRO_IMAGE"
@@ -35,35 +39,35 @@ const esMasterNodeReplicas = "ES_MASTER_NODE_REPLICAS"
 const accessControlAllowOrigin = "ACCESS_CONTROL_ALLOW_ORIGIN"
 
 func getCohMicroImage() string {
-	return os.Getenv(cohMicroImage)
+	return GetEnvFunc(cohMicroImage)
 }
 
 func getHelidonMicroImage() string {
-	return os.Getenv(helidonMicroImage)
+	return GetEnvFunc(helidonMicroImage)
 }
 
 func getWlsMicroImage() string {
-	return os.Getenv(wlsMicroImage)
+	return GetEnvFunc(wlsMicroImage)
 }
 
 // GetPromtheusPusherImage returns the Prometheus Pusher image.
 func GetPromtheusPusherImage() string {
-	return os.Getenv(prometheusPusherImage)
+	return GetEnvFunc(prometheusPusherImage)
 }
 
 // GetNodeExporterImage returns the Node Exporter image.
 func GetNodeExporterImage() string {
-	return os.Getenv(nodeExporterImage)
+	return GetEnvFunc(nodeExporterImage)
 }
 
 // GetFilebeatImage returns the Filebeats image.
 func GetFilebeatImage() string {
-	return os.Getenv(filebeatImage)
+	return GetEnvFunc(filebeatImage)
 }
 
 // GetJournalbeatImage returns the Journabeats image.
 func GetJournalbeatImage() string {
-	return os.Getenv(journalbeatImage)
+	return GetEnvFunc(journalbeatImage)
 }
 
 // GetTestWlsFrontendImage returns a dummy application image for tests.
@@ -73,62 +77,62 @@ func GetTestWlsFrontendImage() string {
 
 // GetWeblogicOperatorImage returns the WebLogic Kubernetes Operator image.
 func GetWeblogicOperatorImage() string {
-	return os.Getenv(weblogicOperatorImage)
+	return GetEnvFunc(weblogicOperatorImage)
 }
 
 // GetFluentdImage returns the Fluentd image.
 func GetFluentdImage() string {
-	return os.Getenv(fluentdImage)
+	return GetEnvFunc(fluentdImage)
 }
 
 // GetCohMicroRequestMemory returns the Coherence micro operator memory request resource.
 func GetCohMicroRequestMemory() string {
-	return os.Getenv(cohMicroRequestMemory)
+	return GetEnvFunc(cohMicroRequestMemory)
 }
 
 // GetHelidonMicroRequestMemory returns the Helidon App micro operator memory request resource.
 func GetHelidonMicroRequestMemory() string {
-	return os.Getenv(helidonMicroRequestMemory)
+	return GetEnvFunc(helidonMicroRequestMemory)
 }
 
 // GetWlsMicroRequestMemory returns the Weblogic micro operator memory request resource.
 func GetWlsMicroRequestMemory() string {
-	return os.Getenv(wlsMicroRequestMemory)
+	return GetEnvFunc(wlsMicroRequestMemory)
 }
 
 // GetElasticsearchMasterNodeRequestMemory returns the Elasticsearch master memory request resource.
 func GetElasticsearchMasterNodeRequestMemory() string {
-	return os.Getenv(esMasterNodeRequestMemory)
+	return GetEnvFunc(esMasterNodeRequestMemory)
 }
 
 // GetElasticsearchIngestNodeRequestMemory returns the Elasticsearch injest memory request resource.
 func GetElasticsearchIngestNodeRequestMemory() string {
-	return os.Getenv(esIngestNodeRequestMemory)
+	return GetEnvFunc(esIngestNodeRequestMemory)
 }
 
 // GetElasticsearchDataNodeRequestMemory returns the Elasticsearch data memory request resource.
 func GetElasticsearchDataNodeRequestMemory() string {
-	return os.Getenv(esDataNodeRequestMemory)
+	return GetEnvFunc(esDataNodeRequestMemory)
 }
 
 // GetGrafanaRequestMemory returns the Grafana memory request resource.
 func GetGrafanaRequestMemory() string {
-	return os.Getenv(grafanaRequestMemory)
+	return GetEnvFunc(grafanaRequestMemory)
 }
 
 // GetPrometheusRequestMemory returns the Prometheus memory request resource.
 func GetPrometheusRequestMemory() string {
-	return os.Getenv(prometheusRequestMemory)
+	return GetEnvFunc(prometheusRequestMemory)
 }
 
 // GetKibanaRequestMemory returns the Kibana memory request resource.
 func GetKibanaRequestMemory() string {
-	return os.Getenv(kibanaRequestMemory)
+	return GetEnvFunc(kibanaRequestMemory)
 }
 
 // GetElasticsearchMasterNodeReplicas returns the Elasticsearch master replicas.
 func GetElasticsearchMasterNodeReplicas() int32 {
-	value := os.Getenv(esMasterNodeReplicas)
+	value := GetEnvFunc(esMasterNodeReplicas)
 	if len(value) != 0 {
 		count, err := strconv.ParseInt(value, 10, 32)
 		if err != nil {
@@ -143,5 +147,5 @@ func GetElasticsearchMasterNodeReplicas() int32 {
 // GetAccessControlAllowOrigin returns the additional allowed origins for API requests - these
 // will be added to the Access-Control-Allow-Origins response header of the API
 func GetAccessControlAllowOrigin() string {
-	return os.Getenv(accessControlAllowOrigin)
+	return GetEnvFunc(accessControlAllowOrigin)
 }


### PR DESCRIPTION
Make API CORS `Access-Control-Allow-Origin` header specific to console instead of "*", with ability to override (needed when UI is run locally for testing purposes, for example)

Also refactored instance_test.go to cover more cases