### PR TITLE
Initial support for generic components

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -11774,4 +11774,4 @@ Creative Commons may be contacted at creativecommons.org.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: dbc24117990cc531b4af71a662fca38a
+License file based on go.mod with md5 sum: c4c8b74bca679c1a8a676e2d429dfa74

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -11774,4 +11774,4 @@ Creative Commons may be contacted at creativecommons.org.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: 9a6bacedd1b606f12ade631e5167fc9d
+License file based on go.mod with md5 sum: dbc24117990cc531b4af71a662fca38a

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	github.com/verrazzano/verrazzano-coh-cluster-operator v0.0.10
-	github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20201001185134-2a3fca73c1d2
+	github.com/verrazzano/verrazzano-crd-generator v0.3.34
 	github.com/verrazzano/verrazzano-helidon-app-operator v0.0.9
 	github.com/verrazzano/verrazzano-monitoring-operator v0.0.24
 	github.com/verrazzano/verrazzano-wko-operator v0.0.12

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/go-retryablehttp v0.6.6
+	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/kylelemons/godebug v1.1.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	github.com/verrazzano/verrazzano-coh-cluster-operator v0.0.10
-	github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20200930163615-6f994f962974
+	github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20201001185134-2a3fca73c1d2
 	github.com/verrazzano/verrazzano-helidon-app-operator v0.0.9
 	github.com/verrazzano/verrazzano-monitoring-operator v0.0.24
 	github.com/verrazzano/verrazzano-wko-operator v0.0.12

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	github.com/verrazzano/verrazzano-coh-cluster-operator v0.0.10
-	github.com/verrazzano/verrazzano-crd-generator v0.3.33
+	github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20200930163615-6f994f962974
 	github.com/verrazzano/verrazzano-helidon-app-operator v0.0.9
 	github.com/verrazzano/verrazzano-monitoring-operator v0.0.24
 	github.com/verrazzano/verrazzano-wko-operator v0.0.12

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/go-retryablehttp v0.6.6
-	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/kylelemons/godebug v1.1.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -500,6 +500,8 @@ github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/jsonnet-bundler/jsonnet-bundler v0.3.1/go.mod h1:/by7P/OoohkI3q4CgSFqcoFsVY+IaNbzOVDknEsKDeU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,7 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7RHGAyAK3EP2EsNk=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
@@ -385,6 +386,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -432,6 +434,7 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -463,6 +466,7 @@ github.com/hashicorp/memberlist v0.1.4/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/memberlist v0.1.5/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.8.5/go.mod h1:UpNcs7fFbpKIyZaUuSW6EPiH+eZC7OuyFD+wc1oal+k=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
@@ -496,8 +500,6 @@ github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/jsonnet-bundler/jsonnet-bundler v0.3.1/go.mod h1:/by7P/OoohkI3q4CgSFqcoFsVY+IaNbzOVDknEsKDeU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -508,9 +510,11 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kshvakov/clickhouse v1.3.5/go.mod h1:DMzX7FxRymoNkVgizH0DWAL8Cur7wHLgx3MUnGwJqpE=
 github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
@@ -609,6 +613,7 @@ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -617,6 +622,7 @@ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -1034,6 +1040,7 @@ golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gomodules.xyz/jsonpatch/v3 v3.0.1/go.mod h1:CBhndykehEwTOlEfnsfJwvkFQbSN8YZFr9M+cIHAJto=
@@ -1105,9 +1112,11 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/fsnotify/fsnotify.v1 v1.4.7/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
@@ -1124,6 +1133,7 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.1.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -231,7 +231,6 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7RHGAyAK3EP2EsNk=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
@@ -386,7 +385,6 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -434,7 +432,6 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -466,7 +463,6 @@ github.com/hashicorp/memberlist v0.1.4/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/memberlist v0.1.5/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.8.5/go.mod h1:UpNcs7fFbpKIyZaUuSW6EPiH+eZC7OuyFD+wc1oal+k=
-github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
@@ -510,11 +506,9 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kshvakov/clickhouse v1.3.5/go.mod h1:DMzX7FxRymoNkVgizH0DWAL8Cur7wHLgx3MUnGwJqpE=
 github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
@@ -613,7 +607,6 @@ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -622,7 +615,6 @@ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
-github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -1040,7 +1032,6 @@ golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gomodules.xyz/jsonpatch/v3 v3.0.1/go.mod h1:CBhndykehEwTOlEfnsfJwvkFQbSN8YZFr9M+cIHAJto=
@@ -1112,11 +1103,9 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/fsnotify/fsnotify.v1 v1.4.7/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
@@ -1133,7 +1122,6 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.1.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -231,7 +231,6 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7RHGAyAK3EP2EsNk=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
@@ -386,7 +385,6 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -434,7 +432,6 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -466,7 +463,6 @@ github.com/hashicorp/memberlist v0.1.4/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/memberlist v0.1.5/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.8.5/go.mod h1:UpNcs7fFbpKIyZaUuSW6EPiH+eZC7OuyFD+wc1oal+k=
-github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
@@ -512,11 +508,9 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kshvakov/clickhouse v1.3.5/go.mod h1:DMzX7FxRymoNkVgizH0DWAL8Cur7wHLgx3MUnGwJqpE=
 github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
@@ -615,7 +609,6 @@ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -624,7 +617,6 @@ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
-github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -800,8 +792,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/verrazzano/verrazzano-coh-cluster-operator v0.0.10 h1:/fiKbcdnKcW2WsAhPRSfUlGZ2BBHsGmsfPew2NC50ik=
 github.com/verrazzano/verrazzano-coh-cluster-operator v0.0.10/go.mod h1:rBbERv1D+QcHlf7aZVulAOjU3Rv4nHOINZhBmcrt9bg=
-github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20201001185134-2a3fca73c1d2 h1:54vn+5l2l4f+DOFN0du4TlsTUfn5AolhLYqbrdxQrvQ=
-github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20201001185134-2a3fca73c1d2/go.mod h1:zm+FruqXAgbgq7Q+F+wA8G4lmsnN8Rv7i2aBup1+DVE=
+github.com/verrazzano/verrazzano-crd-generator v0.3.34 h1:PK3gnja/uFE86Pz2ADTDC70H6F+2xiM9H0DqN+Ly1r8=
+github.com/verrazzano/verrazzano-crd-generator v0.3.34/go.mod h1:zm+FruqXAgbgq7Q+F+wA8G4lmsnN8Rv7i2aBup1+DVE=
 github.com/verrazzano/verrazzano-helidon-app-operator v0.0.9 h1:l3Peda81Ldc55Zn+vzLto2PgzJEv08i/rVlfnrTX+/c=
 github.com/verrazzano/verrazzano-helidon-app-operator v0.0.9/go.mod h1:RVTNJZZ6toH1fJmZVwlpcNXXnzG8kth0FdyPG9m9pq4=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.24 h1:np1OG3+h7qUkvYu3yfwpLe9MqlmU/niL8rHkZ36hWJM=
@@ -874,7 +866,6 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f h1:J5lckAjkw6qYlOZNj90mLYNTEKDvWeuc1yieZ8qUzUE=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -918,7 +909,6 @@ golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -1040,12 +1030,10 @@ golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b h1:AFZdJUT7jJYXQEC29hYH/WZkoV7+KhwxQGmdZ19yYoY=
 golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gomodules.xyz/jsonpatch/v3 v3.0.1/go.mod h1:CBhndykehEwTOlEfnsfJwvkFQbSN8YZFr9M+cIHAJto=
@@ -1117,11 +1105,9 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/fsnotify/fsnotify.v1 v1.4.7/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
@@ -1138,7 +1124,6 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.1.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -792,10 +792,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/verrazzano/verrazzano-coh-cluster-operator v0.0.10 h1:/fiKbcdnKcW2WsAhPRSfUlGZ2BBHsGmsfPew2NC50ik=
 github.com/verrazzano/verrazzano-coh-cluster-operator v0.0.10/go.mod h1:rBbERv1D+QcHlf7aZVulAOjU3Rv4nHOINZhBmcrt9bg=
-github.com/verrazzano/verrazzano-crd-generator v0.3.33 h1:RIcInQTJqKzREph8MwWccxTXyzGnPa1lCskVQzy8kmk=
-github.com/verrazzano/verrazzano-crd-generator v0.3.33/go.mod h1:m9coaK+3mJPr+jVWJ18ydpUg/CD659dFxiSshiEudtw=
-github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20200930163615-6f994f962974 h1:iBl0pJ/6J1yUF6Z/8pn9DFioMlvXkMdX/+xWuZ3fo30=
-github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20200930163615-6f994f962974/go.mod h1:zm+FruqXAgbgq7Q+F+wA8G4lmsnN8Rv7i2aBup1+DVE=
+github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20201001185134-2a3fca73c1d2 h1:54vn+5l2l4f+DOFN0du4TlsTUfn5AolhLYqbrdxQrvQ=
+github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20201001185134-2a3fca73c1d2/go.mod h1:zm+FruqXAgbgq7Q+F+wA8G4lmsnN8Rv7i2aBup1+DVE=
 github.com/verrazzano/verrazzano-helidon-app-operator v0.0.9 h1:l3Peda81Ldc55Zn+vzLto2PgzJEv08i/rVlfnrTX+/c=
 github.com/verrazzano/verrazzano-helidon-app-operator v0.0.9/go.mod h1:RVTNJZZ6toH1fJmZVwlpcNXXnzG8kth0FdyPG9m9pq4=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.24 h1:np1OG3+h7qUkvYu3yfwpLe9MqlmU/niL8rHkZ36hWJM=

--- a/go.sum
+++ b/go.sum
@@ -794,6 +794,8 @@ github.com/verrazzano/verrazzano-coh-cluster-operator v0.0.10 h1:/fiKbcdnKcW2WsA
 github.com/verrazzano/verrazzano-coh-cluster-operator v0.0.10/go.mod h1:rBbERv1D+QcHlf7aZVulAOjU3Rv4nHOINZhBmcrt9bg=
 github.com/verrazzano/verrazzano-crd-generator v0.3.33 h1:RIcInQTJqKzREph8MwWccxTXyzGnPa1lCskVQzy8kmk=
 github.com/verrazzano/verrazzano-crd-generator v0.3.33/go.mod h1:m9coaK+3mJPr+jVWJ18ydpUg/CD659dFxiSshiEudtw=
+github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20200930163615-6f994f962974 h1:iBl0pJ/6J1yUF6Z/8pn9DFioMlvXkMdX/+xWuZ3fo30=
+github.com/verrazzano/verrazzano-crd-generator v0.3.34-0.20200930163615-6f994f962974/go.mod h1:zm+FruqXAgbgq7Q+F+wA8G4lmsnN8Rv7i2aBup1+DVE=
 github.com/verrazzano/verrazzano-helidon-app-operator v0.0.9 h1:l3Peda81Ldc55Zn+vzLto2PgzJEv08i/rVlfnrTX+/c=
 github.com/verrazzano/verrazzano-helidon-app-operator v0.0.9/go.mod h1:RVTNJZZ6toH1fJmZVwlpcNXXnzG8kth0FdyPG9m9pq4=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.24 h1:np1OG3+h7qUkvYu3yfwpLe9MqlmU/niL8rHkZ36hWJM=

--- a/pkg/api/secrets/secrets_test.go
+++ b/pkg/api/secrets/secrets_test.go
@@ -243,7 +243,7 @@ func TestUpdateSecretWhereSecretDoesNotExists(t *testing.T) {
 	recorder := testutil.InvokeHTTPHandler(request, "/secret/{id}", UpdateSecret)
 
 	// THEN test the http response code and body is correct.
-	assert.Equal(http.StatusNotFound, recorder.Code, "Should return a HTTP not foudn status.")
+	assert.Equal(http.StatusNotFound, recorder.Code, "Should return a HTTP not found status.")
 	assert.Contains(string(recorder.Body.Bytes()), "test-secret-uid-1", "Should return a body containing the attempted secret id.")
 
 	// THEN test that the update was not applied to the kubernetes secrets.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -490,7 +490,7 @@ func (c *Controller) createManagedClusterResourcesForBinding(mbPair *types.Model
 		glog.Errorf("Failed to create service entries for binding %s: %v", mbPair.Binding.Name, err)
 	}
 
-	// Create Service for Node Exporter
+	// Create Services
 	err = managed.CreateServices(mbPair, filteredConnections)
 	if err != nil {
 		glog.Errorf("Failed to create service for binding %s: %v", mbPair.Binding.Name, err)
@@ -876,7 +876,7 @@ func (c *Controller) processApplicationBindingDeleted(cluster interface{}) {
 		glog.Errorf("Failed to delete prometheus-pusher for binding %s: %v", mbPair.Binding.Name, err)
 	}
 
-	// Delete Namespaces - this will also cleanup any deployments, Ingresses,
+	// Delete Namespaces - this will also cleanup any Ingresses,
 	// ServiceEntries, ServiceAccounts, ConfigMaps and Secrets within the namespace
 	err = managed.DeleteNamespaces(mbPair, c.managedClusterConnections, true)
 	if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -490,16 +490,16 @@ func (c *Controller) createManagedClusterResourcesForBinding(mbPair *types.Model
 		glog.Errorf("Failed to create service entries for binding %s: %v", mbPair.Binding.Name, err)
 	}
 
-	// Create Services
-	err = managed.CreateServices(mbPair, filteredConnections)
-	if err != nil {
-		glog.Errorf("Failed to create service for binding %s: %v", mbPair.Binding.Name, err)
-	}
-
 	// Create Deployments
 	err = managed.CreateDeployments(mbPair, filteredConnections, c.Manifest, c.verrazzanoURI, c.secrets)
 	if err != nil {
 		glog.Errorf("Failed to create deployments for binding %s: %v", mbPair.Binding.Name, err)
+	}
+
+	// Create Services
+	err = managed.CreateServices(mbPair, filteredConnections)
+	if err != nil {
+		glog.Errorf("Failed to create service for binding %s: %v", mbPair.Binding.Name, err)
 	}
 
 	// Create Custom Resources
@@ -758,16 +758,16 @@ func (c *Controller) cleanupOrphanedResources(mbPair *types.ModelBindingPair) {
 		glog.Errorf("Failed to cleanup custom resources for binding %s: %v", mbPair.Binding.Name, err)
 	}
 
-	// Cleanup Deployments for generic components
-	err = managed.CleanupOrphanedDeployments(mbPair, c.managedClusterConnections)
-	if err != nil {
-		glog.Errorf("Failed to cleanup deployments for binding %s: %v", mbPair.Binding.Name, err)
-	}
-
 	// Cleanup Services for generic components
 	err = managed.CleanupOrphanedServices(mbPair, c.managedClusterConnections)
 	if err != nil {
 		glog.Errorf("Failed to cleanup services for binding %s: %v", mbPair.Binding.Name, err)
+	}
+
+	// Cleanup Deployments for generic components
+	err = managed.CleanupOrphanedDeployments(mbPair, c.managedClusterConnections)
+	if err != nil {
+		glog.Errorf("Failed to cleanup deployments for binding %s: %v", mbPair.Binding.Name, err)
 	}
 
 	// Cleanup ServiceEntries
@@ -874,17 +874,17 @@ func (c *Controller) processApplicationBindingDeleted(cluster interface{}) {
 		return
 	}
 
-	// Delete Deployments for generic components
-	err = managed.DeleteDeployments(mbPair, filteredConnections)
-	if err != nil {
-		glog.Errorf("Failed to delete deployments for binding %s: %v", mbPair.Binding.Name, err)
-		return
-	}
-
 	// Delete Services for generic components
 	err = managed.DeleteServices(mbPair, filteredConnections)
 	if err != nil {
 		glog.Errorf("Failed to delete services for binding %s: %v", mbPair.Binding.Name, err)
+		return
+	}
+
+	// Delete Deployments for generic components
+	err = managed.DeleteDeployments(mbPair, filteredConnections)
+	if err != nil {
+		glog.Errorf("Failed to delete deployments for binding %s: %v", mbPair.Binding.Name, err)
 		return
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -862,6 +862,11 @@ func (c *Controller) processApplicationBindingDeleted(cluster interface{}) {
 	 * Delete Artifacts in the Managed Cluster
 	 **********************/
 
+	filteredConnections, err := util.GetManagedClustersForVerrazzanoBinding(mbPair, c.managedClusterConnections)
+	if err != nil {
+		glog.Errorf("Failed to get filtered connections for binding %s: %v", mbPair.Binding.Name, err)
+	}
+
 	// Delete Custom Resources
 	err = managed.DeleteCustomResources(mbPair, c.managedClusterConnections)
 	if err != nil {
@@ -870,14 +875,14 @@ func (c *Controller) processApplicationBindingDeleted(cluster interface{}) {
 	}
 
 	// Delete Deployments for generic components
-	err = managed.DeleteDeployments(mbPair, c.managedClusterConnections)
+	err = managed.DeleteDeployments(mbPair, filteredConnections)
 	if err != nil {
 		glog.Errorf("Failed to delete deployments for binding %s: %v", mbPair.Binding.Name, err)
 		return
 	}
 
 	// Delete Services for generic components
-	err = managed.DeleteServices(mbPair, c.managedClusterConnections)
+	err = managed.DeleteServices(mbPair, filteredConnections)
 	if err != nil {
 		glog.Errorf("Failed to delete services for binding %s: %v", mbPair.Binding.Name, err)
 		return

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -758,6 +758,18 @@ func (c *Controller) cleanupOrphanedResources(mbPair *types.ModelBindingPair) {
 		glog.Errorf("Failed to cleanup custom resources for binding %s: %v", mbPair.Binding.Name, err)
 	}
 
+	// Cleanup Deployments for generic components
+	err = managed.CleanupOrphanedDeployments(mbPair, c.managedClusterConnections)
+	if err != nil {
+		glog.Errorf("Failed to cleanup deployments for binding %s: %v", mbPair.Binding.Name, err)
+	}
+
+	// Cleanup Services for generic components
+	err = managed.CleanupOrphanedServices(mbPair, c.managedClusterConnections)
+	if err != nil {
+		glog.Errorf("Failed to cleanup services for binding %s: %v", mbPair.Binding.Name, err)
+	}
+
 	// Cleanup ServiceEntries
 	err = managed.CleanupOrphanedServiceEntries(mbPair, c.managedClusterConnections)
 	if err != nil {
@@ -854,6 +866,20 @@ func (c *Controller) processApplicationBindingDeleted(cluster interface{}) {
 	err = managed.DeleteCustomResources(mbPair, c.managedClusterConnections)
 	if err != nil {
 		glog.Errorf("Failed to delete custom resources for binding %s: %v", mbPair.Binding.Name, err)
+		return
+	}
+
+	// Delete Deployments for generic components
+	err = managed.DeleteDeployments(mbPair, c.managedClusterConnections)
+	if err != nil {
+		glog.Errorf("Failed to delete deployments for binding %s: %v", mbPair.Binding.Name, err)
+		return
+	}
+
+	// Delete Services for generic components
+	err = managed.DeleteServices(mbPair, c.managedClusterConnections)
+	if err != nil {
+		glog.Errorf("Failed to delete services for binding %s: %v", mbPair.Binding.Name, err)
 		return
 	}
 

--- a/pkg/controller/model_binding_pair.go
+++ b/pkg/controller/model_binding_pair.go
@@ -344,6 +344,8 @@ func buildModelBindingPair(mbPair *types.ModelBindingPair) *types.ModelBindingPa
 				compNames[s.Name] = s
 			}
 
+			// Process rest connections for WebLogic domains identifying rest connections across clusters
+			// and adding needed environment variables
 			domains := mbPair.Model.Spec.WeblogicDomains
 			if domains != nil {
 				for _, domain := range domains {
@@ -358,6 +360,8 @@ func buildModelBindingPair(mbPair *types.ModelBindingPair) *types.ModelBindingPa
 				}
 			}
 
+			// Process rest connections for Coherence clusters identifying rest connections across clusters
+			// and adding needed environment variables
 			cohClusters := mbPair.Model.Spec.CoherenceClusters
 			if cohClusters != nil {
 				for _, cluster := range cohClusters {
@@ -372,6 +376,8 @@ func buildModelBindingPair(mbPair *types.ModelBindingPair) *types.ModelBindingPa
 				}
 			}
 
+			// Process rest connections for Helidon applications identifying rest connections across clusters
+			// and adding needed environment variables
 			helidonApps := mbPair.Model.Spec.HelidonApplications
 			if helidonApps != nil {
 				for _, app := range helidonApps {
@@ -386,6 +392,8 @@ func buildModelBindingPair(mbPair *types.ModelBindingPair) *types.ModelBindingPa
 				}
 			}
 
+			// Process rest connections for generic components identifying rest connections across clusters
+			// and adding needed environment variables
 			genericComponents := mbPair.Model.Spec.GenericComponents
 			if genericComponents != nil {
 				for _, generic := range genericComponents {
@@ -394,7 +402,7 @@ func buildModelBindingPair(mbPair *types.ModelBindingPair) *types.ModelBindingPa
 						for _, connection := range generic.Connections {
 							createRemoteRestConnections(mbPair, mc, connection.Rest, namespace.Name)
 							envVars := getRestConnectionEnvVars(mbPair, connection.Rest, generic.Name)
-							genericcomp.AddEnvVars(mc, generic.Name, envVars)
+							genericcomp.UpdateEnvVars(mc, generic.Name, envVars)
 						}
 					}
 				}

--- a/pkg/controller/model_binding_pair.go
+++ b/pkg/controller/model_binding_pair.go
@@ -304,7 +304,9 @@ func buildModelBindingPair(mbPair *types.ModelBindingPair) *types.ModelBindingPa
 
 					// Create k8s service for this generic component
 					service := genericcomp.NewService(generic, namespace, genericLabels)
-					mc.Services = append(mc.Services, service)
+					if service != nil {
+						mc.Services = append(mc.Services, service)
+					}
 
 					// Get all the secrets required by the generic component deployment
 					secrets := genericcomp.GetSecrets(*deploy)
@@ -318,10 +320,12 @@ func buildModelBindingPair(mbPair *types.ModelBindingPair) *types.ModelBindingPa
 					// Initial implementation uses the first service port value for the ingress connection.  In the
 					// future, we must allow for multiple ingress connections for generic components with different
 					// service ports.
-					virtualSerivceDestinationPort := int(service.Spec.Ports[0].Port)
-					processIngressConnections(mc, generic.Connections, namespace, nil,
-						getGenericComponentDestinationHost(generic.Name, namespace),
-						virtualSerivceDestinationPort, &mbPair.Binding.Spec.IngressBindings)
+					if service != nil {
+						virtualSerivceDestinationPort := int(service.Spec.Ports[0].Port)
+						processIngressConnections(mc, generic.Connections, namespace, nil,
+							getGenericComponentDestinationHost(generic.Name, namespace),
+							virtualSerivceDestinationPort, &mbPair.Binding.Spec.IngressBindings)
+					}
 				}
 			}
 		}

--- a/pkg/controller/model_binding_pair.go
+++ b/pkg/controller/model_binding_pair.go
@@ -316,7 +316,9 @@ func buildModelBindingPair(mbPair *types.ModelBindingPair) *types.ModelBindingPa
 								}(),
 								Annotations: deployment.Annotations,
 							},
-							Spec: deployment.Spec,
+							Spec: func() appsv1.DeploymentSpec {
+								return *deployment.Spec.DeepCopy()
+							}(),
 						}
 						mc.Deployments = append(mc.Deployments, deploy)
 

--- a/pkg/controller/testdata/generic-binding.yaml
+++ b/pkg/controller/testdata/generic-binding.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: verrazzano.io/v1beta1
+kind: VerrazzanoBinding
+metadata:
+  name: generic-binding
+  namespace: default
+spec:
+  description: "Test Generic Component binding"
+  modelName: generic-model
+  placement:
+    - name: local
+      namespaces:
+        - name: generic
+          components:
+            - name: test-generic
+  ingressBindings:
+    - name: "test-ingress"
+      dnsName: "*"

--- a/pkg/controller/testdata/generic-model.yaml
+++ b/pkg/controller/testdata/generic-model.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: verrazzano.io/v1beta1
+kind: VerrazzanoModel
+metadata:
+  name: generic-model
+  namespace: default
+spec:
+  description: "Test Generic Component model"
+  genericComponents:
+    - name: "test-generic"
+      replicas: 2
+      deployment:
+        containers:
+          - image: generic-image:1.0
+            name: test-generic-image
+            imagePullPolicy: IfNotPresent
+            ports:
+              - containerPort: 8090
+                name: test-port
+                protocol: TCP
+        imagePullSecrets:
+          - name: github-packages
+          - name: ocr
+      connections:
+        - rest:
+            - target: "test-generic"
+              environmentVariableForHost: "BACKEND_HOSTNAME"
+              environmentVariableForPort: "BACKEND_PORT"

--- a/pkg/genericcomp/genericcomp.go
+++ b/pkg/genericcomp/genericcomp.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package genericcomp
 
 import (

--- a/pkg/genericcomp/genericcomp.go
+++ b/pkg/genericcomp/genericcomp.go
@@ -1,0 +1,36 @@
+package genericcomp
+
+import (
+	"github.com/verrazzano/verrazzano-operator/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// UpdateEnvVars updates env variables for a given generic component.
+func UpdateEnvVars(mc *types.ManagedCluster, component string, envs *[]corev1.EnvVar) {
+	if *envs != nil && len(*envs) != 0 {
+		for _, generic := range mc.GenericComponents {
+			if generic.Name == component {
+				for _, deployment := range mc.Deployments {
+					if deployment.Name == component {
+						for index, container := range deployment.Spec.Template.Spec.Containers {
+							for _, env := range *envs {
+								found := false
+								for _, cenv := range container.Env {
+									if cenv.Name == env.Name {
+										found = true
+									}
+								}
+								// Only add env variable to container if the env variable does not already exist.
+								if !found {
+									container.Env = append(container.Env, env)
+								}
+							}
+							deployment.Spec.Template.Spec.Containers[index] = *container.DeepCopy()
+						}
+						return
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/genericcomp/genericcomp.go
+++ b/pkg/genericcomp/genericcomp.go
@@ -76,6 +76,11 @@ func NewService(generic v1beta1v8o.VerrazzanoGenericComponent, namespace string,
 		}
 	}
 
+	// No ports then no need for a service
+	if len(service.Spec.Ports) == 0 {
+		return nil
+	}
+
 	return service
 }
 

--- a/pkg/genericcomp/genericcomp.go
+++ b/pkg/genericcomp/genericcomp.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// GenericComponentSelectorLabel defines the selector label for generic component resources.
 const GenericComponentSelectorLabel = "verrazzano.name"
 
 // NewDeployment constructs a deployment for a generic component.

--- a/pkg/genericcomp/genericcomp.go
+++ b/pkg/genericcomp/genericcomp.go
@@ -4,12 +4,112 @@
 package genericcomp
 
 import (
+	v1beta1v8o "github.com/verrazzano/verrazzano-crd-generator/pkg/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano-operator/pkg/types"
+	"github.com/verrazzano/verrazzano-operator/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// UpdateEnvVars updates env variables for a given generic component.
-func UpdateEnvVars(mc *types.ManagedCluster, component string, envs *[]corev1.EnvVar) {
+const GenericComponentSelectorLabel = "verrazzano.name"
+
+// NewDeployment constructs a deployment for a generic component.
+func NewDeployment(generic v1beta1v8o.VerrazzanoGenericComponent, namespace string, labels map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generic.Name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func() *int32 {
+				if generic.Replicas == nil {
+					return util.NewVal(1)
+				}
+				return generic.Replicas
+			}(),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					GenericComponentSelectorLabel: generic.Name,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						GenericComponentSelectorLabel: generic.Name,
+					},
+				},
+				Spec: generic.Deployment,
+			},
+		},
+	}
+}
+
+// NewService constructs a service for a generic component.
+func NewService(generic v1beta1v8o.VerrazzanoGenericComponent, namespace string, labels map[string]string) *corev1.Service {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generic.Name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				GenericComponentSelectorLabel: generic.Name,
+			},
+			Ports: []corev1.ServicePort{},
+			Type:  corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	// Add all container ports to the k8s service
+	for _, container := range generic.Deployment.Containers {
+		for _, port := range container.Ports {
+			sp := corev1.ServicePort{
+				Name:     port.Name,
+				Protocol: port.Protocol,
+				Port:     port.ContainerPort,
+			}
+			service.Spec.Ports = append(service.Spec.Ports, sp)
+		}
+	}
+
+	return service
+}
+
+// GetSecrets returns the secrets required by a generic component deployment.
+func GetSecrets(deploy appsv1.Deployment) []string {
+	var secrets []string
+
+	// Capture any image pull secrets
+	for _, secret := range deploy.Spec.Template.Spec.ImagePullSecrets {
+		secrets = append(secrets, secret.Name)
+	}
+
+	// Capture any secrets referenced in container env variables
+	for _, container := range deploy.Spec.Template.Spec.Containers {
+		for _, env := range container.Env {
+			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+				secrets = append(secrets, env.ValueFrom.SecretKeyRef.Name)
+			}
+		}
+	}
+
+	// Capture any secrets referenced in init container env variables
+	for _, container := range deploy.Spec.Template.Spec.InitContainers {
+		for _, env := range container.Env {
+			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+				secrets = append(secrets, env.ValueFrom.SecretKeyRef.Name)
+			}
+		}
+	}
+
+	return secrets
+}
+
+// AddEnvVars adds environment variables to a generic components deployment container.
+func AddEnvVars(mc *types.ManagedCluster, component string, envs *[]corev1.EnvVar) {
 	if *envs != nil && len(*envs) != 0 {
 		for _, generic := range mc.GenericComponents {
 			if generic.Name == component {

--- a/pkg/genericcomp/genericcomp.go
+++ b/pkg/genericcomp/genericcomp.go
@@ -129,20 +129,19 @@ func UpdateEnvVars(mc *types.ManagedCluster, component string, envs *[]corev1.En
 
 // Add environment variables to containers
 func addContainerEnvs(envs *[]corev1.EnvVar, containers []corev1.Container) {
-	for index, container := range containers {
+	for containerIndex, _ := range containers {
 		for _, env := range *envs {
 			found := false
-			for i, cenv := range container.Env {
+			for envIndex, cenv := range containers[containerIndex].Env {
 				if cenv.Name == env.Name {
-					container.Env[i].Value = env.Value
+					containers[containerIndex].Env[envIndex].Value = env.Value
 					found = true
 				}
 			}
 			// Only add env variable to container if the env variable does not already exist.
 			if !found {
-				container.Env = append(container.Env, env)
+				containers[containerIndex].Env = append(containers[containerIndex].Env, env)
 			}
 		}
-		containers[index] = *container.DeepCopy()
 	}
 }

--- a/pkg/genericcomp/genericcomp.go
+++ b/pkg/genericcomp/genericcomp.go
@@ -108,8 +108,8 @@ func GetSecrets(deploy appsv1.Deployment) []string {
 	return secrets
 }
 
-// AddEnvVars adds environment variables to a generic components deployment container.
-func AddEnvVars(mc *types.ManagedCluster, component string, envs *[]corev1.EnvVar) {
+// UpdateEnvVars adds environment variables to a generic components deployment container.
+func UpdateEnvVars(mc *types.ManagedCluster, component string, envs *[]corev1.EnvVar) {
 	if envs == nil || len(*envs) == 0 {
 		return
 	}
@@ -127,7 +127,7 @@ func AddEnvVars(mc *types.ManagedCluster, component string, envs *[]corev1.EnvVa
 	}
 }
 
-// add environment variables to containers
+// Add environment variables to containers
 func addContainerEnvs(envs *[]corev1.EnvVar, containers []corev1.Container) {
 	for index, container := range containers {
 		for _, env := range *envs {

--- a/pkg/genericcomp/genericcomp.go
+++ b/pkg/genericcomp/genericcomp.go
@@ -129,7 +129,7 @@ func UpdateEnvVars(mc *types.ManagedCluster, component string, envs *[]corev1.En
 
 // Add environment variables to containers
 func addContainerEnvs(envs *[]corev1.EnvVar, containers []corev1.Container) {
-	for containerIndex, _ := range containers {
+	for containerIndex := range containers {
 		for _, env := range *envs {
 			found := false
 			for envIndex, cenv := range containers[containerIndex].Env {

--- a/pkg/genericcomp/genericcomp_test.go
+++ b/pkg/genericcomp/genericcomp_test.go
@@ -146,6 +146,11 @@ func TestNewService(t *testing.T) {
 	assert.Equal("test-port", service.Spec.Ports[0].Name, "service port name not equal to expected value")
 	assert.Equal(int32(8095), service.Spec.Ports[0].Port, "service port name not equal to expected value")
 	assert.Equal(corev1.ProtocolTCP, service.Spec.Ports[0].Protocol, "service port name not equal to expected value")
+
+	// No container ports specified then no new service is needed.
+	generic.Deployment.Containers[0].Ports = []corev1.ContainerPort{}
+	service = NewService(generic, "test-namespace", labels)
+	assert.Nil(service, "service should be nil")
 }
 
 // TestGetSecrets tests that a list of secrets is returned
@@ -208,4 +213,15 @@ func TestAddEnvVars(t *testing.T) {
 	assert.Equal("test_value3", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[0].Value, "environment variable value not equal to expected value")
 	assert.Equal("test_env2", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[1].Name, "environment variable name not equal to expected value")
 	assert.Equal("test_value2", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[1].Value, "environment variable value not equal to expected value")
+
+	// Specify nil for env vars - should be no change
+	AddEnvVars(mc, "test-generic", nil)
+	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.Containers[0].Env), "environment variable list length not equal to expected value")
+	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env), "environment variable list length not equal to expected value")
+
+	// Specify empty env vars array - should be no change
+	AddEnvVars(mc, "test-generic", &[]corev1.EnvVar{})
+	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.Containers[0].Env), "environment variable list length not equal to expected value")
+	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env), "environment variable list length not equal to expected value")
+
 }

--- a/pkg/genericcomp/genericcomp_test.go
+++ b/pkg/genericcomp/genericcomp_test.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2020, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package genericcomp
+
+import (
+	"testing"
+
+	"github.com/verrazzano/verrazzano-operator/pkg/testutil"
+
+	"github.com/verrazzano/verrazzano-operator/pkg/util"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano-crd-generator/pkg/apis/verrazzano/v1beta1"
+	"github.com/verrazzano/verrazzano-operator/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var generic = v1beta1.VerrazzanoGenericComponent{
+	Name: "test-generic",
+	Deployment: corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "test-container-name",
+				Image: "test-image",
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "test-port",
+						Protocol:      corev1.ProtocolTCP,
+						ContainerPort: 8095,
+					},
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "test-env-name1",
+						Value: "test-env-value",
+					},
+					{
+						Name: "test-env-name2",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								Key: "password",
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "test-secret-ref1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		InitContainers: []corev1.Container{
+			{
+				Name: "test-container-name",
+				Command: []string{
+					"test-command",
+					"--test-arg",
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name: "test-env-name2",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								Key: "password",
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "test-secret-ref2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{
+				Name: "test-secret1",
+			},
+		},
+	},
+}
+
+// TestNewDeployment tests that a deployment is created
+// GIVEN a generic component definition
+//  WHEN I call NewDeployment
+//  THEN the expected generic component deployment should be created
+func TestNewDeployment(t *testing.T) {
+	assert := assert.New(t)
+
+	labels := map[string]string{
+		constants.K8SAppLabel:       constants.VerrazzanoGroup,
+		constants.VerrazzanoBinding: "test-binding",
+		constants.VerrazzanoCluster: "cluster1",
+	}
+	matchLabels := map[string]string{
+		GenericComponentSelectorLabel: generic.Name,
+	}
+
+	generic.Replicas = util.NewVal(2)
+
+	deploy := NewDeployment(generic, "test-namespace", labels)
+	assert.Equal("test-generic", deploy.Name, "deployment name not equal to expected value")
+	assert.Equal("test-namespace", deploy.Namespace, "deployment namespace not equal to expected value")
+	assert.Equal(labels, deploy.Labels, "deployment labels not equal to expected value")
+	assert.Equal(int32(2), *deploy.Spec.Replicas, "deployment replicas not equal to expected value")
+	assert.Equal(matchLabels, deploy.Spec.Selector.MatchLabels, "deployment selector match labels not equal to expected value")
+	assert.Equal(matchLabels, deploy.Spec.Template.Labels, "deployment template labels not equal to expected value")
+	assert.Equal(deploy.Spec.Template.Spec, generic.Deployment, "deployment temp spec not equal to expected value")
+
+	// Unset the replica value to make sure default value of 1 is used.
+	generic.Replicas = nil
+
+	deploy = NewDeployment(generic, "test-namespace", labels)
+	assert.Equal("test-generic", deploy.Name, "deployment name not equal to expected value")
+	assert.Equal("test-namespace", deploy.Namespace, "deployment namespace not equal to expected value")
+	assert.Equal(labels, deploy.Labels, "deployment labels not equal to expected value")
+	assert.Equal(int32(1), *deploy.Spec.Replicas, "deployment replicas not equal to expected value")
+	assert.Equal(matchLabels, deploy.Spec.Selector.MatchLabels, "deployment selector match labels not equal to expected value")
+	assert.Equal(matchLabels, deploy.Spec.Template.Labels, "deployment template labels not equal to expected value")
+	assert.Equal(deploy.Spec.Template.Spec, generic.Deployment, "deployment temp spec not equal to expected value")
+}
+
+// TestNewService tests that a service is created
+// GIVEN a generic component definition
+//  WHEN I call NewService
+//  THEN the expected generic component service should be created
+func TestNewService(t *testing.T) {
+	assert := assert.New(t)
+
+	labels := map[string]string{
+		constants.K8SAppLabel:       constants.VerrazzanoGroup,
+		constants.VerrazzanoBinding: "test-binding",
+		constants.VerrazzanoCluster: "cluster1",
+	}
+
+	selector := map[string]string{
+		GenericComponentSelectorLabel: generic.Name,
+	}
+
+	service := NewService(generic, "test-namespace", labels)
+	assert.Equal("test-generic", service.Name, "service name not equal to expected value")
+	assert.Equal("test-namespace", service.Namespace, "service namespace not equal to expected value")
+	assert.Equal(labels, service.Labels, "service labels not equal to expected value")
+	assert.Equal(selector, service.Spec.Selector, "service selector not equal to expected value")
+	assert.Equal(corev1.ServiceTypeClusterIP, service.Spec.Type, "service type not equal to expected value")
+	assert.Equal(1, len(service.Spec.Ports), "service port list length not equal to expected value")
+	assert.Equal("test-port", service.Spec.Ports[0].Name, "service port name not equal to expected value")
+	assert.Equal(int32(8095), service.Spec.Ports[0].Port, "service port name not equal to expected value")
+	assert.Equal(corev1.ProtocolTCP, service.Spec.Ports[0].Protocol, "service port name not equal to expected value")
+}
+
+// TestGetSecrets tests that a list of secrets is returned
+// GIVEN a deployment specification
+//  WHEN I call GetSecrets
+//  THEN the secrets referenced by the deployment are returned
+func TestGetSecrets(t *testing.T) {
+	assert := assert.New(t)
+
+	labels := map[string]string{
+		constants.K8SAppLabel:       constants.VerrazzanoGroup,
+		constants.VerrazzanoBinding: "test-binding",
+		constants.VerrazzanoCluster: "cluster1",
+	}
+
+	deploy := NewDeployment(generic, "test-namespace", labels)
+
+	secrets := GetSecrets(*deploy)
+	assert.Equal(3, len(secrets), "secrets list length not equal to expected value")
+	assert.Equal("test-secret1", secrets[0], "secret not equal to expected value")
+	assert.Equal("test-secret-ref1", secrets[1], "secret not equal to expected value")
+	assert.Equal("test-secret-ref2", secrets[2], "secret not equal to expected value")
+}
+
+// TestAddEnvVars tests env variables are added to a generic component deployment
+// GIVEN a managed cluster struct, a generic component name, and a list of environment variables to add
+//  WHEN I call AddEnvVars
+//  THEN the environment variables are added to a generic component deployment
+func TestAddEnvVars(t *testing.T) {
+	assert := assert.New(t)
+
+	modelBindingPair := testutil.GetModelBindingPair()
+	mc := modelBindingPair.ManagedClusters["cluster1"]
+
+	envs := []corev1.EnvVar{
+		{
+			Name:  "test_env1",
+			Value: "test_value1",
+		},
+		{
+			Name:  "test_env2",
+			Value: "test_value2",
+		},
+		// environment variable that already exist - will be replaced
+		{
+			Name:  "test_env1",
+			Value: "test_value3",
+		},
+	}
+
+	AddEnvVars(mc, "test-generic", &envs)
+	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.Containers[0].Env), "environment variable list length not equal to expected value")
+	assert.Equal("test_env1", mc.Deployments[0].Spec.Template.Spec.Containers[0].Env[0].Name, "environment variable name not equal to expected value")
+	assert.Equal("test_value3", mc.Deployments[0].Spec.Template.Spec.Containers[0].Env[0].Value, "environment variable value not equal to expected value")
+	assert.Equal("test_env2", mc.Deployments[0].Spec.Template.Spec.Containers[0].Env[1].Name, "environment variable name not equal to expected value")
+	assert.Equal("test_value2", mc.Deployments[0].Spec.Template.Spec.Containers[0].Env[1].Value, "environment variable value not equal to expected value")
+
+	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env), "environment variable list length not equal to expected value")
+	assert.Equal("test_env1", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[0].Name, "environment variable name not equal to expected value")
+	assert.Equal("test_value3", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[0].Value, "environment variable value not equal to expected value")
+	assert.Equal("test_env2", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[1].Name, "environment variable name not equal to expected value")
+	assert.Equal("test_value2", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[1].Value, "environment variable value not equal to expected value")
+}

--- a/pkg/genericcomp/genericcomp_test.go
+++ b/pkg/genericcomp/genericcomp_test.go
@@ -194,7 +194,7 @@ func TestUpdateEnvVars(t *testing.T) {
 			Name:  "test_env2",
 			Value: "test_value2",
 		},
-		// environment variable that already exist - will be replaced
+		// environment variable that already exist - will be replaced because it has a different value
 		{
 			Name:  "test_env1",
 			Value: "test_value3",
@@ -223,4 +223,28 @@ func TestUpdateEnvVars(t *testing.T) {
 	UpdateEnvVars(mc, "test-generic", &[]corev1.EnvVar{})
 	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.Containers[0].Env), "environment variable list length not equal to expected value")
 	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env), "environment variable list length not equal to expected value")
+
+	envs = []corev1.EnvVar{
+		{
+			Name:  "test_env1",
+			Value: "test_value1",
+		},
+		{
+			Name:  "test_env2",
+			Value: "test_value2",
+		},
+		// environment variable that already exist - will not be replaced because value is the same
+		{
+			Name:  "test_env1",
+			Value: "test_value1",
+		},
+	}
+
+	UpdateEnvVars(mc, "test-generic", &envs)
+	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env), "environment variable list length not equal to expected value")
+	assert.Equal("test_env1", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[0].Name, "environment variable name not equal to expected value")
+	assert.Equal("test_value1", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[0].Value, "environment variable value not equal to expected value")
+	assert.Equal("test_env2", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[1].Name, "environment variable name not equal to expected value")
+	assert.Equal("test_value2", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[1].Value, "environment variable value not equal to expected value")
+
 }

--- a/pkg/genericcomp/genericcomp_test.go
+++ b/pkg/genericcomp/genericcomp_test.go
@@ -175,11 +175,11 @@ func TestGetSecrets(t *testing.T) {
 	assert.Equal("test-secret-ref2", secrets[2], "secret not equal to expected value")
 }
 
-// TestAddEnvVars tests env variables are added to a generic component deployment
+// TestUpdateEnvVars tests env variables are added to a generic component deployment
 // GIVEN a managed cluster struct, a generic component name, and a list of environment variables to add
-//  WHEN I call AddEnvVars
+//  WHEN I call UpdateEnvVars
 //  THEN the environment variables are added to a generic component deployment
-func TestAddEnvVars(t *testing.T) {
+func TestUpdateEnvVars(t *testing.T) {
 	assert := assert.New(t)
 
 	modelBindingPair := testutil.GetModelBindingPair()
@@ -201,7 +201,7 @@ func TestAddEnvVars(t *testing.T) {
 		},
 	}
 
-	AddEnvVars(mc, "test-generic", &envs)
+	UpdateEnvVars(mc, "test-generic", &envs)
 	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.Containers[0].Env), "environment variable list length not equal to expected value")
 	assert.Equal("test_env1", mc.Deployments[0].Spec.Template.Spec.Containers[0].Env[0].Name, "environment variable name not equal to expected value")
 	assert.Equal("test_value3", mc.Deployments[0].Spec.Template.Spec.Containers[0].Env[0].Value, "environment variable value not equal to expected value")
@@ -215,13 +215,12 @@ func TestAddEnvVars(t *testing.T) {
 	assert.Equal("test_value2", mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env[1].Value, "environment variable value not equal to expected value")
 
 	// Specify nil for env vars - should be no change
-	AddEnvVars(mc, "test-generic", nil)
+	UpdateEnvVars(mc, "test-generic", nil)
 	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.Containers[0].Env), "environment variable list length not equal to expected value")
 	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env), "environment variable list length not equal to expected value")
 
 	// Specify empty env vars array - should be no change
-	AddEnvVars(mc, "test-generic", &[]corev1.EnvVar{})
+	UpdateEnvVars(mc, "test-generic", &[]corev1.EnvVar{})
 	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.Containers[0].Env), "environment variable list length not equal to expected value")
 	assert.Equal(2, len(mc.Deployments[0].Spec.Template.Spec.InitContainers[0].Env), "environment variable list length not equal to expected value")
-
 }

--- a/pkg/helidonapp/helidonapp_test.go
+++ b/pkg/helidonapp/helidonapp_test.go
@@ -70,9 +70,9 @@ func TestCreateHelidonAppWithCoherenceCluster(t *testing.T) {
 	assert.NotNil(t, findEnv(helidonApp.Spec.Env, myEnvVar.Name))
 }
 
-// TestCreateHelidonAppWithWrongCoherenceCluster tests the creation of HelidonApp witn an invalid VerrazzanoCoherenceConnection
+// TestCreateHelidonAppWithWrongCoherenceCluster tests the creation of HelidonApp with an invalid VerrazzanoCoherenceConnection
 // GIVEN a ModelBindingPair with VerrazzanoCoherenceCluster in VerrazzanoModel and a VerrazzanoHelidonBinding in VerrazzanoBinding
-//  WHEN CreateHelidonAppCR is called with a VerrazzanoHelidon witn an invalid VerrazzanoCoherenceConnection
+//  WHEN CreateHelidonAppCR is called with a VerrazzanoHelidon with an invalid VerrazzanoCoherenceConnection
 //  THEN there should be a HelidonApp created without coherence env vars
 func TestCreateHelidonAppWithWrongCoherenceCluster(t *testing.T) {
 	mcName, namespace, appName := "myCluster", "myNs", "myHelidonApp"

--- a/pkg/managed/configmaps.go
+++ b/pkg/managed/configmaps.go
@@ -57,11 +57,11 @@ func createUpdateConfigMaps(managedClusterConnection *util.ManagedClusterConnect
 		specDiffs := diff.CompareIgnoreTargetEmpties(existingcm, newConfigMap)
 		if specDiffs != "" {
 			glog.V(6).Infof("ConfigMap %s : Spec differences %s", newConfigMap.Name, specDiffs)
-			glog.V(4).Infof("Updating ConfigMap %s in cluster %s", newConfigMap.Name, clusterName)
+			glog.V(4).Infof("Updating ConfigMap %s:%s in cluster %s", newConfigMap.Namespace, newConfigMap.Name, clusterName)
 			_, err = managedClusterConnection.KubeClient.CoreV1().ConfigMaps(newConfigMap.Namespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
 		}
 	} else {
-		glog.V(4).Infof("Creating ConfigMap %s in cluster %s", newConfigMap.Name, clusterName)
+		glog.V(4).Infof("Creating ConfigMap %s:%s in cluster %s", newConfigMap.Namespace, newConfigMap.Name, clusterName)
 		_, err = managedClusterConnection.KubeClient.CoreV1().ConfigMaps(newConfigMap.Namespace).Create(context.TODO(), newConfigMap, metav1.CreateOptions{})
 	}
 	if err != nil {
@@ -91,7 +91,7 @@ func CleanupOrphanedConfigMaps(mbPair *types.ModelBindingPair, availableManagedC
 		}
 		// Delete these ConfigMaps since none are expected on this cluster
 		for _, configMap := range existingConfigMapsList {
-			glog.V(4).Infof("Deleting ConfigMap %s in cluster %s", configMap.Name, clusterName)
+			glog.V(4).Infof("Deleting ConfigMap %s:%s in cluster %s", configMap.Namespace, configMap.Name, clusterName)
 			err := managedClusterConnection.KubeClient.CoreV1().ConfigMaps(configMap.Namespace).Delete(context.TODO(), configMap.Name, metav1.DeleteOptions{})
 			if err != nil {
 				return err

--- a/pkg/managed/crs.go
+++ b/pkg/managed/crs.go
@@ -346,7 +346,7 @@ func CreateCustomResources(mbPair *types.ModelBindingPair, availableManagedClust
 
 // DeleteCustomResources deletes custom resources for a given binding.
 func DeleteCustomResources(mbPair *types.ModelBindingPair, availableManagedClusterConnections map[string]*util.ManagedClusterConnection) error {
-	glog.V(6).Infof("Deleting ServiceAccount for VerrazzanoApplicationBinding %s", mbPair.Binding.Name)
+	glog.V(6).Infof("Deleting Custom Resources for VerrazzanoApplicationBinding %s", mbPair.Binding.Name)
 
 	// Parse out the managed clusters that this binding applies to
 	managedClusters, err := util.GetManagedClustersForVerrazzanoBinding(mbPair, availableManagedClusterConnections)

--- a/pkg/managed/deployment.go
+++ b/pkg/managed/deployment.go
@@ -77,14 +77,8 @@ func CreateDeployments(mbPair *types.ModelBindingPair, filteredConnections map[s
 }
 
 // DeleteDeployments deletes deployments for a given binding.
-func DeleteDeployments(mbPair *types.ModelBindingPair, availableManagedClusterConnections map[string]*util.ManagedClusterConnection) error {
+func DeleteDeployments(mbPair *types.ModelBindingPair, filteredConnections map[string]*util.ManagedClusterConnection) error {
 	glog.V(6).Infof("Deleting Deployments for VerrazzanoBinding %s", mbPair.Binding.Name)
-
-	// Parse out the managed clusters that this binding applies to
-	filteredConnections, err := util.GetManagedClustersForVerrazzanoBinding(mbPair, availableManagedClusterConnections)
-	if err != nil {
-		return nil
-	}
 
 	// Delete Deployments associated with the given VerrazzanoBinding (based on labels selectors)
 	for clusterName, managedClusterConnection := range filteredConnections {

--- a/pkg/managed/deployment.go
+++ b/pkg/managed/deployment.go
@@ -46,10 +46,14 @@ func CreateDeployments(mbPair *types.ModelBindingPair, availableManagedClusterCo
 				continue
 			}
 		} else {
-			deployments, err = newDeployments(mbPair.Binding, managedClusterObj, manifest, verrazzanoURI, sec)
+			deployments, err = newSystemDeployments(mbPair.Binding, managedClusterObj, manifest, verrazzanoURI, sec)
 			if err != nil {
 				glog.Errorf("Error creating new deployments %v", err)
 				continue
+			}
+			// Add deployments from genericComponents
+			for _, deployment := range managedClusterObj.Deployments {
+				deployments = append(deployments, deployment)
 			}
 		}
 
@@ -77,8 +81,8 @@ func CreateDeployments(mbPair *types.ModelBindingPair, availableManagedClusterCo
 	return nil
 }
 
-// Constructs the necessary Deployments for the specified ManagedCluster in the given VerrazzanoBinding
-func newDeployments(binding *v1beta1v8o.VerrazzanoBinding, managedCluster *types.ManagedCluster, manifest *util.Manifest, verrazzanoURI string, sec monitoring.Secrets) ([]*appsv1.Deployment, error) {
+// Constructs the necessary Verrazzano system deployments for the specified ManagedCluster in the given VerrazzanoBinding
+func newSystemDeployments(binding *v1beta1v8o.VerrazzanoBinding, managedCluster *types.ManagedCluster, manifest *util.Manifest, verrazzanoURI string, sec monitoring.Secrets) ([]*appsv1.Deployment, error) {
 	managedNamespace := util.GetManagedClusterNamespaceForSystem()
 	deployPromPusher := true //temporary variable to create pusher deployment
 	depLabels := util.GetManagedLabelsNoBinding(managedCluster.Name)

--- a/pkg/managed/deployment_test.go
+++ b/pkg/managed/deployment_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/verrazzano/verrazzano-operator/pkg/genericcomp"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-operator/pkg/monitoring"
@@ -201,13 +203,13 @@ func TestCleanupOrphanedDeploymentsInvalidBinding(t *testing.T) {
 			}(),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"verrazzano.name": "test-generic",
+					genericcomp.GenericComponentSelectorLabel: "test-generic",
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"verrazzano.name": "test-generic",
+						genericcomp.GenericComponentSelectorLabel: "test-generic",
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/managed/deployment_test.go
+++ b/pkg/managed/deployment_test.go
@@ -4,6 +4,9 @@ package managed
 
 import (
 	"context"
+	"reflect"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-operator/pkg/monitoring"
@@ -13,8 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"reflect"
-	"testing"
 )
 
 var origGetEnvFunc = util.GetEnvFunc
@@ -42,10 +43,10 @@ func TestCreateDeployments(t *testing.T) {
 	err := CreateDeployments(modelBindingPair, clusterConnections, &manifest, "testURI", secrets)
 	assert.Nil(err, "got an error from CreateDeployments: %v", err)
 
-	assertDeployments(err, clusterConnection, assert)
+	assertDeployments(err, clusterConnection, assert, true)
 }
 
-// TestCreateDeployments tests that an existing deployment is properly updated.
+// TestCreateDeploymentsUpdateExisting tests that an existing deployment is properly updated.
 // GIVEN a cluster which has an existing expected deployment (verrazzano-wko-operator)
 //  WHEN I call CreateDeployments
 //  THEN there should be an expected set of deployments created
@@ -78,7 +79,7 @@ func TestCreateDeploymentsUpdateExisting(t *testing.T) {
 	err = CreateDeployments(modelBindingPair, clusterConnections, &manifest, "testURI", secrets)
 	assert.Nil(err, "got an error from CreateDeployments: %v", err)
 
-	assertDeployments(err, clusterConnection, assert)
+	assertDeployments(err, clusterConnection, assert, true)
 }
 
 // TestCreateDeploymentsVmiSystem tests the creation of deployments when the binding name is 'system'.
@@ -111,6 +112,138 @@ func TestCreateDeploymentsVmiSystem(t *testing.T) {
 	assertExpectedDeployments(t, clusterConnection, expectedDeployments)
 }
 
+// TestDeleteDeployments tests that an existing deployment is properly deleted.
+// GIVEN a cluster which has an existing generic component deployment (test-generic)
+//  WHEN I call DeleteDeployments
+//  THEN we delete only the deployment (test-generic) for the generic component
+func TestDeleteDeployments(t *testing.T) {
+	assert := assert.New(t)
+
+	modelBindingPair := testutil.GetModelBindingPair()
+	clusterConnections := testutil.GetManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster1"]
+	manifest := testutil.GetManifest()
+	vmiSecret := monitoring.NewVmiSecret(modelBindingPair.Binding)
+	secrets := &testutil.FakeSecrets{Secrets: map[string]*corev1.Secret{
+		constants.VmiSecretName: vmiSecret,
+	}}
+
+	// temporarily set util.GetEnvFunc to mock response
+	util.GetEnvFunc = getenv
+	defer func() { util.GetEnvFunc = origGetEnvFunc }()
+
+	err := CreateDeployments(modelBindingPair, clusterConnections, &manifest, "testURI", secrets)
+	assert.Nil(err, "got an error from CreateDeployments: %v", err)
+	assertDeployments(err, clusterConnection, assert, true)
+
+	err = DeleteDeployments(modelBindingPair, clusterConnections)
+	assert.Nil(err, "got an error from DeleteDeployments: %v", err)
+	assertDeployments(err, clusterConnection, assert, false)
+}
+
+// TestCleanupOrphanedDeploymentsValidBinding tests that an deployment that has been orphaned is deleted.
+// GIVEN a valid binding for a cluster that has an unexpected generic component deployment (test-generic)
+//  WHEN I call CleanupOrphanedDeployments
+//  THEN the unexpected generic component deployment (test-generic) should be deleted from the cluster
+func TestCleanupOrphanedDeploymentsValidBinding(t *testing.T) {
+	assert := assert.New(t)
+
+	modelBindingPair := testutil.GetModelBindingPair()
+	clusterConnections := testutil.GetManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster1"]
+	manifest := testutil.GetManifest()
+	vmiSecret := monitoring.NewVmiSecret(modelBindingPair.Binding)
+	secrets := &testutil.FakeSecrets{Secrets: map[string]*corev1.Secret{
+		constants.VmiSecretName: vmiSecret,
+	}}
+
+	// temporarily set util.GetEnvFunc to mock response
+	util.GetEnvFunc = getenv
+	defer func() { util.GetEnvFunc = origGetEnvFunc }()
+
+	err := CreateDeployments(modelBindingPair, clusterConnections, &manifest, "testURI", secrets)
+	assert.Nil(err, "got an error from CreateDeployments: %v", err)
+	assertDeployments(err, clusterConnection, assert, true)
+
+	// First attempt will not cleanup any deployments.
+	err = CleanupOrphanedDeployments(modelBindingPair, clusterConnections)
+	assert.Nil(err, "got an error from CleanupOrphanedDeployments: %v", err)
+	assertDeployments(err, clusterConnection, assert, true)
+
+	// Second attempt will cleanup the orphaned generic component deployment (test-generic)
+	modelBindingPair.ManagedClusters["cluster1"].Deployments = []*appsv1.Deployment{}
+	err = CleanupOrphanedDeployments(modelBindingPair, clusterConnections)
+	assert.Nil(err, "got an error from CleanupOrphanedDeployments: %v", err)
+	assertDeployments(err, clusterConnection, assert, false)
+}
+
+// TestCleanupOrphanedDeploymentsInvalidBinding tests that an deployment that has been orphaned is deleted.
+// GIVEN an invalid binding for a cluster that has an unexpected generic component deployment (test-generic)
+//  WHEN I call CleanupOrphanedDeployments
+//  THEN the unexpected generic component deployment (test-generic) should be deleted from the cluster
+func TestCleanupOrphanedDeploymentsInvalidBinding(t *testing.T) {
+	assert := assert.New(t)
+
+	modelBindingPair := testutil.GetModelBindingPair()
+	clusterConnections := testutil.GetManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster3"]
+
+	// Construct a deployment for cluster3
+	deploy := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-generic",
+			Namespace: "test",
+			Labels:    util.GetManagedBindingLabels(modelBindingPair.Binding, "cluster3"),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func() *int32 {
+				return util.NewVal(2)
+			}(),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"verrazzano.name": "test-generic",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"verrazzano.name": "test-generic",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-generic",
+							Image: "test-generic-image",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "test-port",
+									ContainerPort: 8900,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Create a deployment in cluster3
+	_, err := clusterConnection.KubeClient.AppsV1().Deployments("test").Create(context.TODO(), &deploy, metav1.CreateOptions{})
+	assert.Nil(err, "got an error creating a deployment: %v", err)
+	deployments, err := clusterConnection.KubeClient.AppsV1().Deployments("test").List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(err, "got an error listing deployments: %v", err)
+	assert.Equal(1, len(deployments.Items), "expected exactly 1 deployment in the test namespace")
+
+	// Cleanup the deployment we created in cluster3 which should not be there per the model/binding pair.
+	err = CleanupOrphanedDeployments(modelBindingPair, clusterConnections)
+	assert.Nil(err, "got an error from CleanupOrphanedDeployments: %v", err)
+	deployments, err = clusterConnection.KubeClient.AppsV1().Deployments("test").List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(err, "got an error listing deployments: %v", err)
+	assert.Equal(0, len(deployments.Items), "expected exactly 0 deployment in the test namespace")
+}
+
 // getenv returns a mocked response for keys used by these tests
 func getenv(key string) string {
 	if key == "WLS_MICRO_REQUEST_MEMORY" || key == "COH_MICRO_REQUEST_MEMORY" || key == "HELIDON_MICRO_REQUEST_MEMORY" {
@@ -120,7 +253,7 @@ func getenv(key string) string {
 }
 
 // assertDeployments validates that the expected deployments have been created
-func assertDeployments(err error, clusterConnection *util.ManagedClusterConnection, assert *assert.Assertions) {
+func assertDeployments(err error, clusterConnection *util.ManagedClusterConnection, assert *assert.Assertions, generic bool) {
 	// validate that the verrazzano-system deployments have been created
 	list, err := clusterConnection.KubeClient.AppsV1().Deployments("verrazzano-system").List(context.TODO(), metav1.ListOptions{})
 	assert.Nil(err, "got error trying to get deployments: %v", err)
@@ -138,6 +271,19 @@ func assertDeployments(err error, clusterConnection *util.ManagedClusterConnecti
 	assert.Equal("prom-pusher-testBinding", list.Items[0].Name, "expected deployment not found")
 	assert.Equal("cluster1", list.Items[0].Labels["verrazzano.cluster"], "label not equal to expected value")
 	assert.Equal("verrazzano.io", list.Items[0].Labels["k8s-app"], "label not equal to expected value")
+	// validate that the generic component deployments have been created
+	list, err = clusterConnection.KubeClient.AppsV1().Deployments("test").List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(err, "got error trying to get deployments: %v", err)
+	if generic {
+		assert.Len(list.Items, 1, "expected exactly 1 deployment in the test namespace")
+		assert.Equal("test-generic", list.Items[0].Name, "expected deployment not found")
+		assert.Equal("cluster1", list.Items[0].Labels["verrazzano.cluster"], "label not equal to expected value")
+		assert.Equal(int32(2), *list.Items[0].Spec.Replicas, "replicas not equal to expected value")
+		assert.Equal("generic-image:1.0", list.Items[0].Spec.Template.Spec.Containers[0].Image, "container image not equal to expected value")
+		assert.Equal("test-generic-image", list.Items[0].Spec.Template.Spec.Containers[0].Name, "container name not equal to expected value")
+	} else {
+		assert.Len(list.Items, 0, "expected exactly 0 deployment in the test namespace")
+	}
 }
 
 // assertExpectedDeployments validates that the current deployments match the given expected deployments

--- a/pkg/managed/secrets.go
+++ b/pkg/managed/secrets.go
@@ -134,6 +134,7 @@ func newSecrets(mbPair *types.ModelBindingPair, managedCluster *types.ManagedClu
 	for namespace, secretNames := range managedCluster.Secrets {
 		for _, secretName := range secretNames {
 			found := false
+			// Filter out duplicate secrets
 			for _, secret := range secrets {
 				if secret.Name == secretName && secret.Namespace == namespace {
 					found = true

--- a/pkg/managed/secrets.go
+++ b/pkg/managed/secrets.go
@@ -123,7 +123,6 @@ func newSecrets(mbPair *types.ModelBindingPair, managedCluster *types.ManagedClu
 				labels["weblogic.domainUID"] = domain.Name
 				secretObj, err := newSecret(secretName, namespace, kubeClientSet, data, labels)
 				if err != nil {
-					// TODO: why info and level 6?
 					glog.V(6).Infof("Copying secret %s to namespace %s for database binding %s is giving error %s", secretName, namespace, databaseBinding.Name, err)
 					continue
 				}
@@ -144,7 +143,6 @@ func newSecrets(mbPair *types.ModelBindingPair, managedCluster *types.ManagedClu
 			if !found {
 				secretObj, err := newSecret(secretName, namespace, kubeClientSet, nil, nil)
 				if err != nil {
-					// TODO: why is error ignored?
 					continue
 				}
 				secrets = append(secrets, secretObj)

--- a/pkg/managed/serviceaccount_test.go
+++ b/pkg/managed/serviceaccount_test.go
@@ -154,7 +154,7 @@ func getManagedConnections() map[string]*util.ManagedClusterConnection {
 	}
 }
 
-// createAppNamespaces creates the namespaces needed for a application binding.
+// createAppNamespaces creates the namespaces needed for an application binding.
 func createAppNamespaces(t *testing.T, managedConnections map[string]*util.ManagedClusterConnection) {
 	var ns = corev1.Namespace{}
 

--- a/pkg/managed/services.go
+++ b/pkg/managed/services.go
@@ -48,11 +48,11 @@ func CreateServices(mbPair *types.ModelBindingPair, filteredConnections map[stri
 				specDiffs := diff.CompareIgnoreTargetEmpties(existingService, newService)
 				if specDiffs != "" {
 					glog.V(6).Infof("Service %s : Spec differences %s", newService.Name, specDiffs)
-					glog.V(4).Infof("Updating Service %s in cluster %s", newService.Name, clusterName)
+					glog.V(4).Infof("Updating Service %s:%s in cluster %s", newService.Namespace, newService.Name, clusterName)
 					_, err = managedClusterConnection.KubeClient.CoreV1().Services(newService.Namespace).Update(context.TODO(), newService, metav1.UpdateOptions{})
 				}
 			} else {
-				glog.V(4).Infof("Creating Service %s in cluster %s", newService.Name, clusterName)
+				glog.V(4).Infof("Creating Service %s:%s in cluster %s", newService.Namespace, newService.Name, clusterName)
 				_, err = managedClusterConnection.KubeClient.CoreV1().Services(newService.Namespace).Create(context.TODO(), newService, metav1.CreateOptions{})
 			}
 			if err != nil {

--- a/pkg/managed/services.go
+++ b/pkg/managed/services.go
@@ -42,18 +42,18 @@ func CreateServices(mbPair *types.ModelBindingPair, filteredConnections map[stri
 		}
 
 		// Create or update Services
-		for _, newService := range services {
-			existingService, err := managedClusterConnection.ServiceLister.Services(newService.Namespace).Get(newService.Name)
+		for _, service := range services {
+			existingService, err := managedClusterConnection.ServiceLister.Services(service.Namespace).Get(service.Name)
 			if existingService != nil {
-				specDiffs := diff.CompareIgnoreTargetEmpties(existingService, newService)
+				specDiffs := diff.CompareIgnoreTargetEmpties(existingService, service)
 				if specDiffs != "" {
-					glog.V(6).Infof("Service %s : Spec differences %s", newService.Name, specDiffs)
-					glog.V(4).Infof("Updating Service %s:%s in cluster %s", newService.Namespace, newService.Name, clusterName)
-					_, err = managedClusterConnection.KubeClient.CoreV1().Services(newService.Namespace).Update(context.TODO(), newService, metav1.UpdateOptions{})
+					glog.V(6).Infof("Service %s : Spec differences %s", service.Name, specDiffs)
+					glog.V(4).Infof("Updating Service %s:%s in cluster %s", service.Namespace, service.Name, clusterName)
+					_, err = managedClusterConnection.KubeClient.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
 				}
 			} else {
-				glog.V(4).Infof("Creating Service %s:%s in cluster %s", newService.Namespace, newService.Name, clusterName)
-				_, err = managedClusterConnection.KubeClient.CoreV1().Services(newService.Namespace).Create(context.TODO(), newService, metav1.CreateOptions{})
+				glog.V(4).Infof("Creating Service %s:%s in cluster %s", service.Namespace, service.Name, clusterName)
+				_, err = managedClusterConnection.KubeClient.CoreV1().Services(service.Namespace).Create(context.TODO(), service, metav1.CreateOptions{})
 			}
 			if err != nil {
 				return err

--- a/pkg/managed/services.go
+++ b/pkg/managed/services.go
@@ -64,14 +64,8 @@ func CreateServices(mbPair *types.ModelBindingPair, filteredConnections map[stri
 }
 
 // DeleteServices deletes services for a given binding.
-func DeleteServices(mbPair *types.ModelBindingPair, availableManagedClusterConnections map[string]*util.ManagedClusterConnection) error {
+func DeleteServices(mbPair *types.ModelBindingPair, filteredConnections map[string]*util.ManagedClusterConnection) error {
 	glog.V(6).Infof("Deleting Services for VerrazzanoBinding %s", mbPair.Binding.Name)
-
-	// Parse out the managed clusters that this binding applies to
-	filteredConnections, err := util.GetManagedClustersForVerrazzanoBinding(mbPair, availableManagedClusterConnections)
-	if err != nil {
-		return nil
-	}
 
 	// Delete Services associated with the given VerrazzanoBinding (based on labels selectors)
 	for clusterName, managedClusterConnection := range filteredConnections {

--- a/pkg/managed/services_test.go
+++ b/pkg/managed/services_test.go
@@ -5,22 +5,23 @@ package managed
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
-	"github.com/verrazzano/verrazzano-operator/pkg/util"
-
-	"github.com/verrazzano/verrazzano-operator/pkg/monitoring"
-
 	"github.com/stretchr/testify/assert"
+	v1beta1v8o "github.com/verrazzano/verrazzano-crd-generator/pkg/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano-operator/pkg/constants"
+	"github.com/verrazzano/verrazzano-operator/pkg/monitoring"
 	"github.com/verrazzano/verrazzano-operator/pkg/testutil"
+	"github.com/verrazzano/verrazzano-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// TestCreateServicesAppBinding model/binding is for application binding - no service is created.
+// TestCreateServicesAppBinding tests the creation of services for an application model/binding
+// GIVEN a cluster which does not have any services
+//  WHEN I call CreateServices
+//  THEN there should be an expected set of services created
 func TestCreateServicesAppBinding(t *testing.T) {
 	assert := assert.New(t)
 
@@ -33,21 +34,16 @@ func TestCreateServicesAppBinding(t *testing.T) {
 
 	services, err := clusterConnection.KubeClient.CoreV1().Services("test").List(context.TODO(), metav1.ListOptions{})
 	assert.Nil(err, "got an error listing services: %v", err)
-	assert.Equal(1, len(services.Items), "expected exactly 1 service in the test namespace")
-	assert.Equal("test-generic", services.Items[0].Name, "service name not equal to expected value")
-	assert.Equal("test", services.Items[0].Namespace, "service namespace not equal to expected value")
-	assert.Equal(util.GetManagedBindingLabels(modelBindingPair.Binding, "cluster1"), services.Items[0].Labels, "labels not equal to expected value")
-	selector := map[string]string{"verrazzano.name": "test-generic"}
-	assert.Equal(selector, services.Items[0].Spec.Selector, "selector not equal to expected value")
-	assert.Equal(corev1.ServiceType("ClusterIP"), services.Items[0].Spec.Type, "service type not equal to expected value")
-	assert.Equal("test-port", services.Items[0].Spec.Ports[0].Name, "port name not equal to expected value")
-	assert.Equal(int32(8090), services.Items[0].Spec.Ports[0].Port, "port not equal to expected value")
-	assert.Equal(intstr.FromInt(0), services.Items[0].Spec.Ports[0].TargetPort, "target port name not equal to expected value")
-	assert.Equal(corev1.Protocol("TCP"), services.Items[0].Spec.Ports[0].Protocol, "protocol name not equal to expected value")
+	assertCreateServiceAppBinding(t, services, modelBindingPair.Binding)
 }
 
-// TestCreateServicesVMIBinding model/binding for VMI system binding - Node Exporter service is created.
+// TestCreateServicesVMIBinding tests the creation of services for a VMI system binding
+// GIVEN a cluster which does not have any services
+//  WHEN I call CreateServices
+//  THEN there should be a Node Exporter service created
 func TestCreateServicesVMIBinding(t *testing.T) {
+	assert := assert.New(t)
+
 	mbPairSystemBinding := testutil.GetModelBindingPair()
 	mbPairSystemBinding.Model.Name = constants.VmiSystemBindingName
 	mbPairSystemBinding.Binding.Name = constants.VmiSystemBindingName
@@ -55,40 +51,156 @@ func TestCreateServicesVMIBinding(t *testing.T) {
 	// Model/binding for VMI system binding - Node Exporter service is created.
 	managedConnections := testutil.GetManagedClusterConnections()
 	err := CreateServices(mbPairSystemBinding, managedConnections)
-	if err != nil {
-		t.Fatal(fmt.Sprintf("can't create service: %v", err))
-	}
+	assert.Nil(err, "got an error from CreateServices: %v", err)
 
 	for clusterName := range mbPairSystemBinding.ManagedClusters {
 		managedClusterConnection := managedConnections[clusterName]
 		existingService, err := managedClusterConnection.KubeClient.CoreV1().Services(constants.MonitoringNamespace).List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			t.Fatal(fmt.Sprintf("can't list service for cluster %s: %v", err, clusterName))
-		}
+		assert.Nil(err, "got an error listing services: %v", err)
 		assertCreateServiceVMI(t, existingService, clusterName)
 
 		// Update the port value so when we call CreateServices again the update code is executed.
 		existingService.Items[0].Spec.Ports[0].Port = 9200
 		_, err = managedClusterConnection.KubeClient.CoreV1().Services(constants.MonitoringNamespace).Update(context.TODO(), &existingService.Items[0], metav1.UpdateOptions{})
-		if err != nil {
-			t.Fatal(fmt.Sprintf("can't update service for cluster %s: %v", err, clusterName))
-		}
+		assert.Nil(err, "got an error updating services: %v", err)
 	}
 
 	// Model/binding for VMI system binding - service already exist
 	err = CreateServices(mbPairSystemBinding, managedConnections)
-	if err != nil {
-		t.Fatal(fmt.Sprintf("can't create service: %v", err))
-	}
+	assert.Nil(err, "got an error from CreateServices: %v", err)
 
 	for clusterName := range mbPairSystemBinding.ManagedClusters {
 		managedClusterConnection := managedConnections[clusterName]
 		existingService, err := managedClusterConnection.KubeClient.CoreV1().Services(constants.MonitoringNamespace).List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			t.Fatal(fmt.Sprintf("can't list service for cluster %s: %v", err, clusterName))
-		}
+		assert.Nil(err, "got an error listing services: %v", err)
 		assertCreateServiceVMI(t, existingService, clusterName)
 	}
+}
+
+// TestDeleteServices tests that an existing service is properly deleted.
+// GIVEN a cluster which has an existing generic component service (test-generic)
+//  WHEN I call CreateServices
+//  THEN we delete only the service (test-generic) for the generic component
+func TestDeleteServices(t *testing.T) {
+	assert := assert.New(t)
+
+	modelBindingPair := testutil.GetModelBindingPair()
+	clusterConnections := testutil.GetManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster1"]
+
+	err := CreateServices(modelBindingPair, clusterConnections)
+	assert.Nil(err, "got an error from CreateServices: %v", err)
+
+	services, err := clusterConnection.KubeClient.CoreV1().Services("test").List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(err, "got an error listing services: %v", err)
+	assertCreateServiceAppBinding(t, services, modelBindingPair.Binding)
+
+	err = DeleteServices(modelBindingPair, clusterConnections)
+	assert.Nil(err, "got an error from DeleteServices: %v", err)
+	services, err = clusterConnection.KubeClient.CoreV1().Services("test").List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(err, "got an error listing services: %v", err)
+	assert.Equal(0, len(services.Items), "expected exactly 0 service in the test namespace")
+}
+
+// TestCleanupOrphanedServicesValidBinding tests that a service that has been orphaned is deleted.
+// GIVEN a valid binding for a cluster that has an unexpected generic component service (test-generic)
+//  WHEN I call CleanupOrphanedServices
+//  THEN the unexpected generic component service (test-generic) should be deleted from the cluster
+func TestCleanupOrphanedServicesValidBinding(t *testing.T) {
+	assert := assert.New(t)
+
+	modelBindingPair := testutil.GetModelBindingPair()
+	clusterConnections := testutil.GetManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster1"]
+
+	err := CreateServices(modelBindingPair, clusterConnections)
+	assert.Nil(err, "got an error from CreateServices: %v", err)
+
+	services, err := clusterConnection.KubeClient.CoreV1().Services("test").List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(err, "got an error listing services: %v", err)
+	assertCreateServiceAppBinding(t, services, modelBindingPair.Binding)
+
+	// First attempt will not cleanup any services.
+	err = CleanupOrphanedServices(modelBindingPair, clusterConnections)
+	assert.Nil(err, "got an error from CleanupOrphanedServices: %v", err)
+	assertCreateServiceAppBinding(t, services, modelBindingPair.Binding)
+
+	// Second attempt will cleanup the orphaned generic component service (test-generic)
+	modelBindingPair.ManagedClusters["cluster1"].Services = []*corev1.Service{}
+	err = CleanupOrphanedServices(modelBindingPair, clusterConnections)
+	assert.Nil(err, "got an error from CleanupOrphanedServices: %v", err)
+
+	services, err = clusterConnection.KubeClient.CoreV1().Services("test").List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(err, "got an error listing services: %v", err)
+	assert.Equal(0, len(services.Items), "expected exactly 0 service in the test namespace")
+}
+
+// TestCleanupOrphanedServicesInvalidBinding tests that a service that has been orphaned is deleted.
+// GIVEN an invalid binding for a cluster that has an unexpected generic component service (test-generic)
+//  WHEN I call CleanupOrphanedServices
+//  THEN the unexpected generic component service (test-generic) should be deleted from the cluster
+func TestCleanupOrphanedServicesInvalidBinding(t *testing.T) {
+	assert := assert.New(t)
+
+	modelBindingPair := testutil.GetModelBindingPair()
+	clusterConnections := testutil.GetManagedClusterConnections()
+	clusterConnection := clusterConnections["cluster3"]
+
+	// Construct a service for cluster3
+	service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-generic",
+			Namespace: "test",
+			Labels:    util.GetManagedBindingLabels(modelBindingPair.Binding, "cluster3"),
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"verrazzano.name": "test-generic",
+			},
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "test-port",
+					Port:     8090,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	// Create a service in cluster3
+	_, err := clusterConnection.KubeClient.CoreV1().Services("test").Create(context.TODO(), &service, metav1.CreateOptions{})
+	assert.Nil(err, "got an error creating a service: %v", err)
+	services, err := clusterConnection.KubeClient.CoreV1().Services("test").List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(err, "got an error listing services: %v", err)
+	assert.Equal(1, len(services.Items), "expected exactly 1 service in the test namespace")
+
+	// Cleanup the service we created in cluster3 which should not be there per the model/binding pair.
+	err = CleanupOrphanedServices(modelBindingPair, clusterConnections)
+	assert.Nil(err, "got an error from CleanupOrphanedServices: %v", err)
+	services, err = clusterConnection.KubeClient.CoreV1().Services("test").List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(err, "got an error listing services: %v", err)
+	assert.Equal(0, len(services.Items), "expected exactly 0 service in the test namespace")
+}
+
+func assertCreateServiceAppBinding(t *testing.T, services *corev1.ServiceList, binding *v1beta1v8o.VerrazzanoBinding) {
+	selector := map[string]string{
+		"verrazzano.name": "test-generic",
+	}
+
+	assert := assert.New(t)
+
+	assert.Equal(1, len(services.Items), "expected exactly 1 service in the test namespace")
+	assert.Equal("test-generic", services.Items[0].Name, "service name not equal to expected value")
+	assert.Equal("test", services.Items[0].Namespace, "service namespace not equal to expected value")
+	assert.Equal(util.GetManagedBindingLabels(binding, "cluster1"), services.Items[0].Labels, "labels not equal to expected value")
+	assert.Equal(selector, services.Items[0].Spec.Selector, "selector not equal to expected value")
+	assert.Equal(corev1.ServiceType("ClusterIP"), services.Items[0].Spec.Type, "service type not equal to expected value")
+	assert.Equal("test-port", services.Items[0].Spec.Ports[0].Name, "port name not equal to expected value")
+	assert.Equal(int32(8090), services.Items[0].Spec.Ports[0].Port, "port not equal to expected value")
+	assert.Equal(intstr.FromInt(0), services.Items[0].Spec.Ports[0].TargetPort, "target port not equal to expected value")
+	assert.Equal(corev1.Protocol("TCP"), services.Items[0].Spec.Ports[0].Protocol, "protocol name not equal to expected value")
+
 }
 
 func assertCreateServiceVMI(t *testing.T, existingService *corev1.ServiceList, clusterName string) {
@@ -99,13 +211,13 @@ func assertCreateServiceVMI(t *testing.T, existingService *corev1.ServiceList, c
 	assert := assert.New(t)
 
 	assert.Equal(1, len(existingService.Items), "one service should be found for cluster %s", clusterName)
-	assert.Equal(constants.NodeExporterName, existingService.Items[0].Name)
-	assert.Equal(constants.MonitoringNamespace, existingService.Items[0].Namespace)
-	assert.Equal(monitoring.GetNodeExporterLabels(clusterName), existingService.Items[0].Labels)
-	assert.Equal(labels, existingService.Items[0].Spec.Selector)
-	assert.Equal(corev1.ServiceType("ClusterIP"), existingService.Items[0].Spec.Type)
-	assert.Equal("metrics", existingService.Items[0].Spec.Ports[0].Name)
-	assert.Equal(int32(9100), existingService.Items[0].Spec.Ports[0].Port)
-	assert.Equal(intstr.FromInt(9100), existingService.Items[0].Spec.Ports[0].TargetPort)
-	assert.Equal(corev1.Protocol("TCP"), existingService.Items[0].Spec.Ports[0].Protocol)
+	assert.Equal(constants.NodeExporterName, existingService.Items[0].Name, "service name not equal to expected value")
+	assert.Equal(constants.MonitoringNamespace, existingService.Items[0].Namespace, "service namespace not equal to expected value")
+	assert.Equal(monitoring.GetNodeExporterLabels(clusterName), existingService.Items[0].Labels, "labels not equal to expected value")
+	assert.Equal(labels, existingService.Items[0].Spec.Selector, "selector not equal to expected value")
+	assert.Equal(corev1.ServiceType("ClusterIP"), existingService.Items[0].Spec.Type, "service type not equal to expected value")
+	assert.Equal("metrics", existingService.Items[0].Spec.Ports[0].Name, "port name not equal to expected value")
+	assert.Equal(int32(9100), existingService.Items[0].Spec.Ports[0].Port, "port not equal to expected value")
+	assert.Equal(intstr.FromInt(9100), existingService.Items[0].Spec.Ports[0].TargetPort, "target port not equal to expected value")
+	assert.Equal(corev1.Protocol("TCP"), existingService.Items[0].Spec.Ports[0].Protocol, "protocol name not equal to expected value")
 }

--- a/pkg/managed/services_test.go
+++ b/pkg/managed/services_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/verrazzano/verrazzano-operator/pkg/genericcomp"
+
 	"github.com/stretchr/testify/assert"
 	v1beta1v8o "github.com/verrazzano/verrazzano-crd-generator/pkg/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano-operator/pkg/constants"
@@ -155,7 +157,7 @@ func TestCleanupOrphanedServicesInvalidBinding(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"verrazzano.name": "test-generic",
+				genericcomp.GenericComponentSelectorLabel: "test-generic",
 			},
 			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
@@ -185,7 +187,7 @@ func TestCleanupOrphanedServicesInvalidBinding(t *testing.T) {
 
 func assertCreateServiceAppBinding(t *testing.T, services *corev1.ServiceList, binding *v1beta1v8o.VerrazzanoBinding) {
 	selector := map[string]string{
-		"verrazzano.name": "test-generic",
+		genericcomp.GenericComponentSelectorLabel: "test-generic",
 	}
 
 	assert := assert.New(t)

--- a/pkg/managed/services_test.go
+++ b/pkg/managed/services_test.go
@@ -81,7 +81,7 @@ func TestCreateServicesVMIBinding(t *testing.T) {
 
 // TestDeleteServices tests that an existing service is properly deleted.
 // GIVEN a cluster which has an existing generic component service (test-generic)
-//  WHEN I call CreateServices
+//  WHEN I call DeleteServices
 //  THEN we delete only the service (test-generic) for the generic component
 func TestDeleteServices(t *testing.T) {
 	assert := assert.New(t)

--- a/pkg/testutil/testdata/test_binding.yaml
+++ b/pkg/testutil/testdata/test_binding.yaml
@@ -16,6 +16,7 @@ spec:
       namespaces:
         - components:
             - name: test-coherence
+            - name: test-generic
           name: test
         - components:
             - name: test-helidon

--- a/pkg/testutil/testdata/test_managed_cluster_1.yaml
+++ b/pkg/testutil/testdata/test_managed_cluster_1.yaml
@@ -70,4 +70,40 @@ WlsOperator:
     namespace: test
     serviceAccount: test
   status: {}
+GenericComponents:
+  - name: test-generic
+    deployment:
+      replicas: 2
+      containers:
+        - image: generic-image:1.0
+          name: test-generic-image
+Deployments:
+  - metadata:
+      creationTimestamp: null
+      name: test-generic
+      namespace: test
+      labels:
+        k8s-app: verrazzano.io
+        verrazzano.binding: testBinding
+        verrazzano.cluster: cluster1
+    spec:
+      replicas: 2
+      selector:
+        matchLabels:
+          verrazzano.name: test-generic
+      template:
+        metadata:
+          labels:
+            verrazzano.name: test-generic
+        spec:
+          containers:
+            - image: generic-image:1.0
+              imagePullPolicy: IfNotPresent
+              name: test-generic-image
+              ports:
+                - containerPort: 8090
+                  name: test-port
+                  protocol: TCP
+    status: {}
+
 

--- a/pkg/testutil/testdata/test_managed_cluster_1.yaml
+++ b/pkg/testutil/testdata/test_managed_cluster_1.yaml
@@ -105,5 +105,21 @@ Deployments:
                   name: test-port
                   protocol: TCP
     status: {}
-
-
+Services:
+  - metadata:
+      creationTimestamp: null
+      name: test-generic
+      namespace: test
+      labels:
+        k8s-app: verrazzano.io
+        verrazzano.binding: testBinding
+        verrazzano.cluster: cluster1
+    spec:
+      ports:
+        - name: test-port
+          port: 8090
+          protocol: TCP
+      selector:
+        verrazzano.name: test-generic
+      type: ClusterIP
+    status: {}

--- a/pkg/testutil/testdata/test_managed_cluster_1.yaml
+++ b/pkg/testutil/testdata/test_managed_cluster_1.yaml
@@ -104,6 +104,9 @@ Deployments:
                 - containerPort: 8090
                   name: test-port
                   protocol: TCP
+          initContainers:
+            - image: generic-image:2.0
+              name: test-generic-image2
     status: {}
 Services:
   - metadata:

--- a/pkg/testutil/testdata/test_model.yaml
+++ b/pkg/testutil/testdata/test_model.yaml
@@ -40,4 +40,15 @@ spec:
               environmentVariableForPort: ""
               target: test-helidon
       name: test-weblogic
+  genericComponents:
+    - name: test-generic
+      deployment:
+        containers:
+          - image: generic-image:1.0
+            name: test-generic-image
+            imagePullPolicy: IfNotPresent
+            ports:
+              - containerPort: 8090
+                name: test-port
+                protocol: TCP
 status: {}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,6 +12,7 @@ import (
 	v8weblogic "github.com/verrazzano/verrazzano-crd-generator/pkg/apis/weblogic/v8"
 	v1helidonapp "github.com/verrazzano/verrazzano-helidon-app-operator/pkg/apis/verrazzano/v1beta1"
 	v1wlsopr "github.com/verrazzano/verrazzano-wko-operator/pkg/apis/verrazzano/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -25,8 +26,10 @@ const (
 	Helidon ComponentType = 1
 	// Coherence component type
 	Coherence ComponentType = 2
+	// Generic component type
+	Generic ComponentType = 3
 	// Unknown component type
-	Unknown ComponentType = 3
+	Unknown ComponentType = 4
 )
 
 // IngressDestination represents a destination ingress.
@@ -88,8 +91,14 @@ type ManagedCluster struct {
 	// Names of ingresses to generate within each namespace for this cluster
 	Ingresses map[string][]*Ingress
 
+	// Deployments for this cluster
+	Deployments []*appsv1.Deployment
+
 	// ConfigMaps for this cluster
 	ConfigMaps []*corev1.ConfigMap
+
+	// Services for this cluster
+	Services []*corev1.Service
 
 	// Remote rest connections (istio ServicEntries) to generate within each namespace for this cluster
 	RemoteRests map[string][]*RemoteRestConnection
@@ -108,6 +117,9 @@ type ManagedCluster struct {
 
 	// Coherence cluster CRs for this cluster
 	CohClusterCRs []*v1cohcluster.CoherenceCluster
+
+	// Generic components for this cluster
+	GenericComponents []*v1beta1v8o.VerrazzanoGenericComponent
 }
 
 // ModelBindingPair represents an instance of a model/binding pair and

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -94,11 +94,11 @@ type ManagedCluster struct {
 	// Deployments for this cluster
 	Deployments []*appsv1.Deployment
 
-	// ConfigMaps for this cluster
-	ConfigMaps []*corev1.ConfigMap
-
 	// Services for this cluster
 	Services []*corev1.Service
+
+	// ConfigMaps for this cluster
+	ConfigMaps []*corev1.ConfigMap
 
 	// Remote rest connections (istio ServicEntries) to generate within each namespace for this cluster
 	RemoteRests map[string][]*RemoteRestConnection


### PR DESCRIPTION
This pull request contains the initial implementation of generic components in the verrazzano-operator.  In addition, unit tests are included for all new code.  A generic component will result in a k8s deployment and optionally a k8s service being created.  The initial implementation includes support for rest and ingress connections.
