### PR TITLE
Minor cleanup of makefile and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Copyright (c) 2020, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 build/_output
+build/deploy
 vendor
 .idea
 **/*.iml

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ go-mod:
 	mv assets.go pkg/assets/
 
 	$(GO) mod vendor
+	$(GO) mod tidy
 
 	# go mod vendor only copies the .go files.  Also need
 	# to populate the vendor folder with the .yaml files

--- a/Makefile
+++ b/Makefile
@@ -227,9 +227,7 @@ endif
 		--config=test/kind-config.yaml
 	kubectl config set-context kind-${CLUSTER_NAME}
 ifdef JENKINS_URL
-	# disabled this - not needed since we are not running from inside docker any more
-	# cat ${HOME}/.kube/config | grep server
-	# this ugly looking line of code will get the ip address of the container running the kube apiserver
+	# Get the ip address of the container running the kube apiserver
 	# and update the kubeconfig file to point to that address, instead of localhost
 	sed -i -e "s|127.0.0.1.*|`docker inspect ${CLUSTER_NAME}-control-plane | jq '.[].NetworkSettings.IPAddress' | sed 's/"//g'`:6443|g" ${HOME}/.kube/config
 	cat ${HOME}/.kube/config | grep server

--- a/test/create-deployment.sh
+++ b/test/create-deployment.sh
@@ -12,8 +12,3 @@ DEPLOY=${BASE_DIR}/build/deploy
 mkdir -p "${DEPLOY}"
 
 cat "${BASE_DIR}"/test/k8resource/deployment.yaml | sed -e "s|IMAGE_NAME:IMAGE_TAG|${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}|g" > "${DEPLOY}"/deployment.yaml
-
-export CA_BUNDLE="`base64 -i "${CERTS}"/verrazzano-crt.pem | tr -d '\n'`"
-
-sed -i -e "s|CA_BUNDLE|${CA_BUNDLE}|g" "${DEPLOY}"/deployment.yaml
-


### PR DESCRIPTION
Do some minor cleanup:
1. Makefile add `go mod tidy` to prevent go.mod and go.sum from being modified and checked out.  
2. Add build/deploy to .gitignore
3. Remove cert logic no longer needed