### PR TITLE
VZ-1740.  Productize dev/prod profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,3 +260,9 @@ push-tag:
 	docker pull "${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG}"; \
 	docker tag "${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG}" "${DOCKER_IMAGE_FULLNAME}:$$PUBLISH_TAG"; \
 	docker push "${DOCKER_IMAGE_FULLNAME}:$$PUBLISH_TAG"
+
+#
+# Run all checks, convenient as a sanity-check before committing/pushing
+#
+.PHONY: check-all
+check-all: go-fmt go-lint go-ineffassign go-vet unit-test

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ HELM_CHART_ARCHIVE_NAME = ${HELM_CHART_NAME}-${HELM_CHART_VERSION}.tgz
 .PHONY: all
 all: build
 
+#
+# Run all checks, convenient as a sanity-check before committing/pushing
+#
 .PHONY: check
 check: go-fmt go-vet go-ineffassign go-lint
 
@@ -261,8 +264,3 @@ push-tag:
 	docker tag "${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG}" "${DOCKER_IMAGE_FULLNAME}:$$PUBLISH_TAG"; \
 	docker push "${DOCKER_IMAGE_FULLNAME}:$$PUBLISH_TAG"
 
-#
-# Run all checks, convenient as a sanity-check before committing/pushing
-#
-.PHONY: check-all
-check-all: go-fmt go-lint go-ineffassign go-vet unit-test

--- a/cmd/verrazzano-operator/main.go
+++ b/cmd/verrazzano-operator/main.go
@@ -194,7 +194,7 @@ func initFlags(
 	stringVarFunc(&watchNamespace, "watchNamespace", "", "Optionally, a namespace to watch exclusively.  If not set, all namespaces will be watched.")
 	stringVarFunc(&verrazzanoURI, "verrazzanoUri", "", "Verrazzano URI, for example my-verrazzano-1.verrazzano.example.com")
 	stringVarFunc(&helidonAppOperatorDeployment, "helidonAppOperatorDeployment", "", "--helidonAppOperatorDeployment=false disables helidonAppOperatorDeployment")
-	stringVarFunc(&enableMonitoringStorage, "enableMonitoringStorage", "", "Enable storage for monitoring.  The default is true. 'false' means monitoring storage is disabled.")
+	stringVarFunc(&enableMonitoringStorage, "enableMonitoringStorage", "true", "Enable storage for monitoring.  The default is true. 'false' means monitoring storage is disabled.")
 	stringVarFunc(&apiServerRealm, "apiServerRealm", "", "API Server Realm on Keycloak")
 	boolVarFunc(&startController, "startController", true, "Whether to start the Kubernetes controller (true by default)")
 	flagSetFunc(flag.CommandLine)

--- a/cmd/verrazzano-operator/main_test.go
+++ b/cmd/verrazzano-operator/main_test.go
@@ -98,7 +98,7 @@ func Test_initFlags(t *testing.T) {
 		"watchNamespace":               "",
 		"verrazzanoUri":                "",
 		"helidonAppOperatorDeployment": "",
-		"enableMonitoringStorage":      "",
+		"enableMonitoringStorage":      "true",
 		"apiServerRealm":               "",
 	}
 	var expectedBoolFlags = map[string]bool{

--- a/pkg/fluentd/fluentd_test.go
+++ b/pkg/fluentd/fluentd_test.go
@@ -93,9 +93,9 @@ func TestCreateFluentdContainer(t *testing.T) {
 	assertion.Equal(true, fluentd.VolumeMounts[2].ReadOnly, "Fluentd container volume mounts read only flag not equal to expected value")
 
 	// In addition test that when Dev mode is set we get the expected elastic search host
-	os.Setenv("INSTALL_PROFILE", constants.DevelopmentProfile)
+	os.Setenv("USE_SYSTEM_VMI", "true")
 	fluentd = CreateFluentdContainer("test-binding", "test-component")
-	os.Unsetenv("INSTALL_PROFILE")
+	os.Unsetenv("USE_SYSTEM_VMI")
 
 	assertion.Equal("fluentd", fluentd.Name, "Fluentd container name not equal to expected value")
 	assertion.Equal(2, len(fluentd.Args), "Fluentd container args count not equal to expected value")

--- a/pkg/local/vmis.go
+++ b/pkg/local/vmis.go
@@ -89,7 +89,7 @@ func createStorageOption(envSetting string, enableMonitoringStorageEnvFlag strin
 	}
 	monitoringStorageEnabled, err := strconv.ParseBool(enableMonitoringStorageEnvFlag)
 	if err != nil {
-		zap.S().Errorf("Invalid storage setting: %s", envSetting)
+		zap.S().Errorf("Invalid storage setting: %s", enableMonitoringStorageEnvFlag)
 	} else if monitoringStorageEnabled && len(envSetting) > 0 {
 		storageSetting = vmov1.Storage{
 			Size: envSetting,

--- a/pkg/local/vmis_test.go
+++ b/pkg/local/vmis_test.go
@@ -43,6 +43,7 @@ const (
 
 func TestCreateStorageOption(t *testing.T) {
 	type args struct {
+		storageValue            string
 		enableMonitoringStorage string
 	}
 	tests := []struct {
@@ -51,39 +52,39 @@ func TestCreateStorageOption(t *testing.T) {
 		want string
 	}{
 		{
-			"false enableMonitoringStorage",
-			args{"false"},
+			"50Gi Enabled",
+			args{"50Gi", "true"},
+			"50Gi",
+		},
+		{
+			"100Gi Enabled",
+			args{"100Gi", "true"},
+			"100Gi",
+		},
+		{
+			"None Enabled",
+			args{"", "true"},
 			"",
 		},
 		{
-			"False enableMonitoringStorage",
-			args{"False"},
+			"100Gi Disabled",
+			args{"100Gi", "false"},
 			"",
 		},
 		{
-			"empty enableMonitoringStorage",
-			args{""},
-			"50Gi",
+			"None Disabled",
+			args{"", "false"},
+			"",
 		},
 		{
-			"true enableMonitoringStorage",
-			args{"true"},
-			"50Gi",
-		},
-		{
-			"True enableMonitoringStorage",
-			args{"True"},
-			"50Gi",
-		},
-		{
-			"random enableMonitoringStorage",
-			args{"random"},
-			"50Gi",
+			"100Gi InvalidFlag",
+			args{"100Gi", "boo"},
+			"",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := createStorageOption(tt.args.enableMonitoringStorage).Size; !reflect.DeepEqual(got, tt.want) {
+			if got := createStorageOption(tt.args.storageValue, tt.args.enableMonitoringStorage).Size; !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("createStorageOption() = %v, want %v", got, tt.want)
 			}
 		})
@@ -133,6 +134,7 @@ func TestCreateInstance(t *testing.T) {
 			false,
 		},
 	}
+	defer func() { os.Unsetenv("USE_SYSTEM_VMI") }()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.args.bindingName == "devProfile" {

--- a/pkg/local/vmis_test.go
+++ b/pkg/local/vmis_test.go
@@ -136,9 +136,9 @@ func TestCreateInstance(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.args.bindingName == "devProfile" {
-				os.Setenv("INSTALL_PROFILE", constants.DevelopmentProfile)
+				os.Setenv("USE_SYSTEM_VMI", "true")
 			} else {
-				os.Unsetenv("INSTALL_PROFILE")
+				os.Unsetenv("USE_SYSTEM_VMI")
 			}
 			got, err := createInstance(createTestBinding(tt.args.bindingName), tt.args.verrazzanoURI, "")
 			if (err != nil) != tt.wantErr {

--- a/pkg/local/vmis_test.go
+++ b/pkg/local/vmis_test.go
@@ -397,6 +397,14 @@ func TestCreateUpdateVmi(t *testing.T) {
 	}
 }
 
+func TestSharedVMIAppBinding(t *testing.T) {
+	os.Setenv("USE_SYSTEM_VMI", "true")
+	defer os.Unsetenv("USE_SYSTEM_VMI")
+
+	err := CreateUpdateVmi(createTestBinding("foo"), fakeVmoClientSet{}, fakeVmiLister{}, "testVerrazzanoURI", "")
+	assert.Nil(t, err, "Unexpected error for shared VMI with app binding")
+}
+
 func TestDeleteVmi(t *testing.T) {
 	type args struct {
 		bindingName string

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -32,7 +32,9 @@ const esMasterNodeRequestMemory = "ES_MASTER_NODE_REQUEST_MEMORY"
 const esIngestNodeRequestMemory = "ES_INGEST_NODE_REQUEST_MEMORY"
 const esDataNodeRequestMemory = "ES_DATA_NODE_REQUEST_MEMORY"
 const grafanaRequestMemory = "GRAFANA_REQUEST_MEMORY"
+const grafanaDataStorageSize = "GRAFANA_DATA_STORAGE"
 const prometheusRequestMemory = "PROMETHEUS_REQUEST_MEMORY"
+const prometheusDataStorageSize = "PROMETHEUS_DATA_STORAGE"
 const kibanaRequestMemory = "KIBANA_REQUEST_MEMORY"
 const esDataNodeReplicas = "ES_DATA_NODE_REPLICAS"
 const esIngestNodeReplicas = "ES_INGEST_NODE_REPLICAS"
@@ -118,17 +120,29 @@ func GetElasticsearchDataNodeRequestMemory() string {
 	return GetEnvFunc(esDataNodeRequestMemory)
 }
 
+// GetElasticsearchDataStorageSize returns the Elasticsearch storage size request
 func GetElasticsearchDataStorageSize() string {
 	return GetEnvFunc(esDataStorageSize)
 }
+
 // GetGrafanaRequestMemory returns the Grafana memory request resource.
 func GetGrafanaRequestMemory() string {
 	return GetEnvFunc(grafanaRequestMemory)
 }
 
+// GetGrafanaDataStorageSize returns the Prometheus storage size request
+func GetGrafanaDataStorageSize() string {
+	return GetEnvFunc(grafanaDataStorageSize)
+}
+
 // GetPrometheusRequestMemory returns the Prometheus memory request resource.
 func GetPrometheusRequestMemory() string {
 	return GetEnvFunc(prometheusRequestMemory)
+}
+
+// GetPrometheusDataStorageSize returns the Prometheus storage size request
+func GetPrometheusDataStorageSize() string {
+	return GetEnvFunc(prometheusDataStorageSize)
 }
 
 // GetKibanaRequestMemory returns the Kibana memory request resource.
@@ -150,17 +164,17 @@ func getEnvReplicaCount(envVarName string, defaultValue int32) int32 {
 	return defaultValue
 }
 
-// GetElasticsearchMasterNodeReplicas returns the Elasticsearch master replicas.
+// GetElasticsearchMasterNodeReplicas returns the Elasticsearch master node replicas.
 func GetElasticsearchMasterNodeReplicas() int32 {
 	return getEnvReplicaCount(esMasterNodeReplicas, 3)
 }
 
-// GetElasticsearchMasterNodeReplicas returns the Elasticsearch master replicas.
+// GetElasticsearchDataNodeReplicas returns the Elasticsearch data node replicas.
 func GetElasticsearchDataNodeReplicas() int32 {
 	return getEnvReplicaCount(esDataNodeReplicas, 2)
 }
 
-// GetElasticsearchMasterNodeReplicas returns the Elasticsearch master replicas.
+// GetElasticsearchIngestNodeReplicas returns the Elasticsearch ingest node replicas.
 func GetElasticsearchIngestNodeReplicas() int32 {
 	return getEnvReplicaCount(esIngestNodeReplicas, 1)
 }

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -34,8 +34,12 @@ const esDataNodeRequestMemory = "ES_DATA_NODE_REQUEST_MEMORY"
 const grafanaRequestMemory = "GRAFANA_REQUEST_MEMORY"
 const prometheusRequestMemory = "PROMETHEUS_REQUEST_MEMORY"
 const kibanaRequestMemory = "KIBANA_REQUEST_MEMORY"
+const esDataNodeReplicas = "ES_DATA_NODE_REPLICAS"
+const esIngestNodeReplicas = "ES_INGEST_NODE_REPLICAS"
 const esMasterNodeReplicas = "ES_MASTER_NODE_REPLICAS"
+const esDataStorageSize = "ES_DATA_STORAGE"
 const accessControlAllowOrigin = "ACCESS_CONTROL_ALLOW_ORIGIN"
+const sharedVMIDefault = "USE_SYSTEM_VMI"
 
 func getCohMicroImage() string {
 	return GetEnvFunc(cohMicroImage)
@@ -114,6 +118,9 @@ func GetElasticsearchDataNodeRequestMemory() string {
 	return GetEnvFunc(esDataNodeRequestMemory)
 }
 
+func GetElasticsearchDataStorageSize() string {
+	return GetEnvFunc(esDataStorageSize)
+}
 // GetGrafanaRequestMemory returns the Grafana memory request resource.
 func GetGrafanaRequestMemory() string {
 	return GetEnvFunc(grafanaRequestMemory)
@@ -129,18 +136,33 @@ func GetKibanaRequestMemory() string {
 	return GetEnvFunc(kibanaRequestMemory)
 }
 
-// GetElasticsearchMasterNodeReplicas returns the Elasticsearch master replicas.
-func GetElasticsearchMasterNodeReplicas() int32 {
-	value := GetEnvFunc(esMasterNodeReplicas)
+// getEnvReplicaCount gets a replica count from the named env var, returning the provided default if not present
+func getEnvReplicaCount(envVarName string, defaultValue int32) int32 {
+	value := GetEnvFunc(envVarName)
 	if len(value) != 0 {
 		count, err := strconv.ParseInt(value, 10, 32)
 		if err != nil {
-			zap.S().Infof("%v is invalid.  The default value of 3 will be used as replicas of ES master node.", value)
+			zap.S().Infof("%s: %v is invalid.  The default value of %v will be used for node replicas.", envVarName, value, defaultValue)
 		} else {
 			return int32(count)
 		}
 	}
-	return 3
+	return defaultValue
+}
+
+// GetElasticsearchMasterNodeReplicas returns the Elasticsearch master replicas.
+func GetElasticsearchMasterNodeReplicas() int32 {
+	return getEnvReplicaCount(esMasterNodeReplicas, 3)
+}
+
+// GetElasticsearchMasterNodeReplicas returns the Elasticsearch master replicas.
+func GetElasticsearchDataNodeReplicas() int32 {
+	return getEnvReplicaCount(esDataNodeReplicas, 2)
+}
+
+// GetElasticsearchMasterNodeReplicas returns the Elasticsearch master replicas.
+func GetElasticsearchIngestNodeReplicas() int32 {
+	return getEnvReplicaCount(esIngestNodeReplicas, 1)
 }
 
 // GetAccessControlAllowOrigin returns the additional allowed origins for API requests - these

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -38,8 +38,12 @@ const prometheusDataStorageSize = "PROMETHEUS_DATA_STORAGE"
 const kibanaRequestMemory = "KIBANA_REQUEST_MEMORY"
 const esDataNodeReplicas = "ES_DATA_NODE_REPLICAS"
 const esIngestNodeReplicas = "ES_INGEST_NODE_REPLICAS"
+const esIngestNodeReplicasDefault = 1
 const esMasterNodeReplicas = "ES_MASTER_NODE_REPLICAS"
+const esMasterNodeReplicasDefault = 3
 const esDataStorageSize = "ES_DATA_STORAGE"
+const esDataNodeReplicasDefault = 2
+
 const accessControlAllowOrigin = "ACCESS_CONTROL_ALLOW_ORIGIN"
 const sharedVMIDefault = "USE_SYSTEM_VMI"
 
@@ -166,17 +170,17 @@ func getEnvReplicaCount(envVarName string, defaultValue int32) int32 {
 
 // GetElasticsearchMasterNodeReplicas returns the Elasticsearch master node replicas.
 func GetElasticsearchMasterNodeReplicas() int32 {
-	return getEnvReplicaCount(esMasterNodeReplicas, 3)
+	return getEnvReplicaCount(esMasterNodeReplicas, esMasterNodeReplicasDefault)
 }
 
 // GetElasticsearchDataNodeReplicas returns the Elasticsearch data node replicas.
 func GetElasticsearchDataNodeReplicas() int32 {
-	return getEnvReplicaCount(esDataNodeReplicas, 2)
+	return getEnvReplicaCount(esDataNodeReplicas, esDataNodeReplicasDefault)
 }
 
 // GetElasticsearchIngestNodeReplicas returns the Elasticsearch ingest node replicas.
 func GetElasticsearchIngestNodeReplicas() int32 {
-	return getEnvReplicaCount(esIngestNodeReplicas, 1)
+	return getEnvReplicaCount(esIngestNodeReplicas, esIngestNodeReplicasDefault)
 }
 
 // GetAccessControlAllowOrigin returns the additional allowed origins for API requests - these

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -282,7 +282,6 @@ func SharedVMIDefault() bool {
 	return useSharedVMI
 }
 
-
 // GetProfileBindingName will return the binding name based on the profile
 // if the profile doesn't have a special binding name, the binding name supplied is returned
 // for Dev profile the VMI system binding name is returned
@@ -293,6 +292,7 @@ func GetProfileBindingName(bindingName string) string {
 	return bindingName
 }
 
+// IsSystemProfileBindingName return true if the specified binding name is the system VMI name
 func IsSystemProfileBindingName(bindingName string) bool {
 	return constants.VmiSystemBindingName == bindingName
 }

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -251,21 +251,24 @@ func TestLoadManifest(t *testing.T) {
 	assert.Error(err, "Error loading manifest")
 }
 
-func TestIsDevProfile(t *testing.T) {
+func TestSharedVMIDefault(t *testing.T) {
 	assert := assert.New(t)
-
-	os.Unsetenv("INSTALL_PROFILE")
-	assert.False(IsDevProfile(), "Expected DevProfile to return false")
-	os.Setenv("INSTALL_PROFILE", constants.DevelopmentProfile)
-	assert.True(IsDevProfile(), "Expected DevProfile to return true")
-	os.Unsetenv("INSTALL_PROFILE")
+	os.Unsetenv("USE_SYSTEM_VMI")
+	assert.False(SharedVMIDefault(), "Expected SharedVMIDefault() to return false when var not set")
+	os.Setenv("USE_SYSTEM_VMI", "false")
+	assert.False(SharedVMIDefault(), "Expected SharedVMIDefault() to return false when var set to false")
+	os.Setenv("USE_SYSTEM_VMI", "boo")
+	assert.False(SharedVMIDefault(), "Expected SharedVMIDefault() to return false when var set to bad value")
+	os.Setenv("USE_SYSTEM_VMI", "true")
+	assert.True(SharedVMIDefault(), "Expected SharedVMIDefault() to return true")
+	os.Unsetenv("USE_SYSTEM_VMI")
 }
 
 func TestGetProfileBindingName(t *testing.T) {
 	assert := assert.New(t)
-	os.Unsetenv("INSTALL_PROFILE")
+	os.Unsetenv("USE_SYSTEM_VMI")
 	assert.Equal("foobar", GetProfileBindingName("foobar"))
-	os.Setenv("INSTALL_PROFILE", constants.DevelopmentProfile)
+	os.Setenv("USE_SYSTEM_VMI", "true")
 	assert.Equal(constants.VmiSystemBindingName, GetProfileBindingName("foobar"))
-	os.Unsetenv("INSTALL_PROFILE")
+	os.Unsetenv("USE_SYSTEM_VMI")
 }

--- a/run-vo.sh
+++ b/run-vo.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+ 
+# If on corporate network set proxy environment variables
+profile=${1-:"dev"}
+
+# Customize these to provide the location of your verrazzano and verrazzano repos
+#export WORK=${HOME}/Projects
+#export VERRAZZANO_REPO=${WORK}/vz/src/github.com/verrazzano/verrazzano
+export VERRAZZANO_OPERATOR_REPO=$(pwd)
+export VERRAZZANO_REPO=${VERRAZZANO_OPERATOR_REPO}/../verrazzano
+  
+echo "Building and installing the verrazzano-operator."
+cd ${VERRAZZANO_OPERATOR_REPO}
+make go-install
+echo ""
+
+echo "Stopping the in-cluster verrazzano-operator."
+set -x
+kubectl scale deployment verrazzano-operator --replicas=0 -n verrazzano-system
+set +x
+echo ""
+  
+# Extract the images required by verrazzano-operator from values.yaml into environment variables.
+export COH_MICRO_IMAGE=$(grep cohMicroImage ${VERRAZZANO_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export HELIDON_MICRO_IMAGE=$(grep helidonMicroImage ${VERRAZZANO_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export WLS_MICRO_IMAGE=$(grep wlsMicroImage ${VERRAZZANO_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export PROMETHEUS_PUSHER_IMAGE=$(grep prometheusPusherImage ${VERRAZZANO_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export NODE_EXPORTER_IMAGE=$(grep nodeExporterImage ${VERRAZZANO_REPO}/install/chart/values.yaml | head -1 | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//' | sort -u)
+export FILEBEAT_IMAGE=$(grep filebeatImage ${VERRAZZANO_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export JOURNALBEAT_IMAGE=$(grep journalbeatImage ${VERRAZZANO_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export WEBLOGIC_OPERATOR_IMAGE=$(grep weblogicOperatorImage ${VERRAZZANO_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export FLUENTD_IMAGE=$(grep fluentdImage ${VERRAZZANO_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export COH_MICRO_REQUEST_MEMORY="28Mi"
+export HELIDON_MICRO_REQUEST_MEMORY="24Mi"
+export WLS_MICRO_REQUEST_MEMORY="32Mi"
+export GRAFANA_REQUEST_MEMORY="48Mi"
+export PROMETHEUS_REQUEST_MEMORY="128Mi"
+export KIBANA_REQUEST_MEMORY="192Mi"
+
+export ES_INGEST_NODE_REQUEST_MEMORY="2.5Gi"
+export ES_DATA_NODE_REQUEST_MEMORY="4.8Gi"
+
+echo "Running ${profile} profile"
+if [ "${profile}" == "dev" ]; then
+  # Dev profile
+  export ES_MASTER_NODE_REQUEST_MEMORY="1Gi"
+  export ES_MASTER_NODE_REPLICAS="1"
+  export ES_DATA_NODE_REPLICAS="0"
+  export ES_INGEST_NODE_REPLICAS="0"
+  export USE_SYSTEM_VMI=true
+  export ES_DATA_STORAGE=""
+  export PROMETHEUS_DATA_STORAGE="50Gi"  # Keep for now?
+  export GRAFANA_DATA_STORAGE="50Gi"     # Keep for now?
+else
+  # Prod profile
+  export ES_MASTER_NODE_REQUEST_MEMORY="1.4Gi"
+  export ES_MASTER_NODE_REPLICAS="3"
+  export ES_DATA_NODE_REPLICAS="2"
+  export ES_INGEST_NODE_REPLICAS="1"
+  export USE_SYSTEM_VMI=false
+  export ES_DATA_STORAGE="50Gi"
+  export PROMETHEUS_DATA_STORAGE="50Gi"
+  export GRAFANA_DATA_STORAGE="50Gi"
+fi
+
+# Extract the API server realm from values.yaml.
+export API_SERVER_REALM=$(grep apiServerRealm ${VERRAZZANO_REPO}/install/chart/values.yaml | cut -d':' -f2 | sed -e 's/^[[:space:]]*//')
+  
+# Extract the Verrazzano system ingress IP from the NGINX ingress controller status.
+export VERRAZZANO_SYSTEM_INGRESS_IP=$(kubectl get svc -n ingress-nginx ingress-controller-nginx-ingress-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+cat <<EOF
+Variables:
+USE_SYSTEM_VMI=${USE_SYSTEM_VMI}
+COH_MICRO_IMAGE=$COH_MICRO_IMAGE
+HELIDON_MICRO_IMAGE=$HELIDON_MICRO_IMAGE
+WLS_MICRO_IMAGE=$WLS_MICRO_IMAGE
+PROMETHEUS_PUSHER_IMAGE=$PROMETHEUS_PUSHER_IMAGE
+NODE_EXPORTER_IMAGE=$NODE_EXPORTER_IMAGE
+FILEBEAT_IMAGE=$FILEBEAT_IMAGE
+JOURNALBEAT_IMAGE=$JOURNALBEAT_IMAGE
+WEBLOGIC_OPERATOR_IMAGE=$WEBLOGIC_OPERATOR_IMAGE
+FLUENTD_IMAGE=$FLUENTD_IMAGE
+WLS_MICRO_REQUEST_MEMORY=$HELIDON_MICRO_REQUEST_MEMORY
+ES_MASTER_NODE_REQUEST_MEMORY=$ES_MASTER_NODE_REQUEST_MEMORY
+ES_INGEST_NODE_REQUEST_MEMORY=$ES_INGEST_NODE_REQUEST_MEMORY
+ES_DATA_NODE_REQUEST_MEMORY=$ES_DATA_NODE_REQUEST_MEMORY
+GRAFANA_REQUEST_MEMORY=$GRAFANA_REQUEST_MEMORY
+PROMETHEUS_REQUEST_MEMORY=$PROMETHEUS_REQUEST_MEMORY
+KIBANA_REQUEST_MEMORY=$KIBANA_REQUEST_MEMORY
+ES_MASTER_NODE_REPLICAS=$ES_MASTER_NODE_REPLICAS
+ES_DATA_NODE_REPLICAS=$ES_DATA_NODE_REPLICAS
+ES_INGEST_NODE_REPLICAS=$ES_INGEST_NODE_REPLICAS
+API_SERVER_REALM=$API_SERVER_REALM
+VERRAZZANO_SYSTEM_INGRESS_IP=$VERRAZZANO_SYSTEM_INGRESS_IP
+ES_DATA_STORAGE=${ES_DATA_STORAGE}
+PROMETHEUS_DATA_STORAGE=${PROMETHEUS_DATA_STORAGE}
+GRAFANA_DATA_STORAGE=${GRAFANA_DATA_STORAGE}
+EOF
+ 
+# Run the out-of-cluster Verrazzano operator.
+cmd="verrazzano-operator\
+ --zap-log-level=debug \
+ --kubeconfig=${KUBECONFIG:-${HOME}/.kube/config}\
+ --verrazzanoUri=default.${VERRAZZANO_SYSTEM_INGRESS_IP}.xip.io\
+ --apiServerRealm=${API_SERVER_REALM}
+
+# --enableMonitoringStorage=${ENABLE_MONITORING_STORAGE}"
+echo "Command"
+echo "${cmd}"
+eval ${cmd}

--- a/run-vo.sh
+++ b/run-vo.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
- 
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 # If on corporate network set proxy environment variables
 profile=${1-:"dev"}
 

--- a/run-vo.sh
+++ b/run-vo.sh
@@ -1,8 +1,35 @@
 #!/bin/bash
 # Copyright (c) 2020, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# This script will run the verrazzano-operator outside of the cluster, for local debugging/testing
+# purposes.
+#
+# Pre-requisites:
+# - golang is installed as described in the README
+# - the verrazzano installer is cloned from github in a parallel directory named to this repo (https://github.com/verrazzano/verrazzano)
+# - kubectl is installed
+# - KUBECONFIG is pointing to a valid Kubernetes cluster
+# - If on corporate network set proxy environment variables
+#
+# Simply run
+#
+#    sh run-vo.sh [profile-name]
+#
+# where
+#
+#    profile-name = [dev|prod]
+#
+# By default, profile-name="dev"
+#
+# When executed, the script will
+#
+# - build the operator
+# - set up the required environment variables for the operator
+# - scale down the in-cluster monitoring operator to 0
+# - Execute the local operator
+# - Once the local operator is terminated (hit Ctrl-C 2x), scale up the in-cluster operator to 1 replica again
 
-# If on corporate network set proxy environment variables
 profile=${1-:"dev"}
 
 # Customize these to provide the location of your verrazzano and verrazzano repos
@@ -111,3 +138,9 @@ cmd="verrazzano-operator\
 echo "Command"
 echo "${cmd}"
 eval ${cmd}
+
+echo "Starting the in-cluster verrazzano-operator."
+set -x
+kubectl scale deployment verrazzano-operator --replicas=1 -n verrazzano-system
+set +x
+echo ""


### PR DESCRIPTION
Re-interpret the notion of install profiles to be a set of fine-grained install-time configuration options, instead of an explicit single global switch.  This change introduces those settings, and how they are used for "dev" vs. "prod" install profiles.

The notion of profiles will then be implemented in the installer through collections of values for a subset of these settings; e.g., the "dev" profile will have a set of values that will correspond to a shared VMI and a single-node ES cluster, without an explicit need for a "profile" switch in the code.

### Existing Settings Used for Profiles
ES_MASTER_NODE_REQUEST_MEMORY
ES_MASTER_NODE_REPLICAS

### New settings:

Setting | Operator Behavior
-- | -- 
USE_SYSTEM_VMI | When set to true, indicates that we should use the System VMI for all application data by default
ES_DATA_NODE_REPLICAS | The number of data node replicas for ES
ES_INGEST_NODE_REPLICAS | The number of ingest node replicas for ES
ES_DATA_STORAGE | The amount of storage to use for ES (if empty, use ephemeral storage)
PROMETHEUS_DATA_STORAGE | The amount of storage to use for Prometheus (if empty, use ephemeral storage)
GRAFANA_DATA_STORAGE | The amount of storage to use for Grafana (if empty, use ephemeral storage)


### Dev profile values:

Dev profile is configured
* to use a single shared VMI for Verrazzano system and application monitoring data
* a single-node Elasticsearch cluster with ephemeral storage
* Prometheus with ephemeral storage
* Kibana with ephemeral storage

Setting | Value
-- | --
USE_SYSTEM_VMI | true 
ES_MASTER_NODE_REQUEST_MEMORY | 1Gi 
ES_MASTER_NODE_REPLICAS | 1 
ES_DATA_NODE_REPLICAS | 0
ES_INGEST_NODE_REPLICAS | 0
ES_DATA_STORAGE  | ""
PROMETHEUS_DATA_STORAGE | ""
GRAFANA_DATA_STORAGE | ""

### Prod profile values:

Prod profile is configured
* Separate VMIs for Verrazzano system and application monitoring data
* multi-node Elasticsearch cluster with 50Gi persistent storage
* Prometheus with 50Gi persistent storage
* Kibana with 50Gi persistent storage

Setting | Value
-- | --
USE_SYSTEM_VMI | true 
ES_MASTER_NODE_REQUEST_MEMORY | 1.4Gi 
ES_MASTER_NODE_REPLICAS | 3
ES_DATA_NODE_REPLICAS | 2
ES_INGEST_NODE_REPLICAS | 1
ES_DATA_STORAGE  | 50Gi
PROMETHEUS_DATA_STORAGE | 50Gi
GRAFANA_DATA_STORAGE | 50Gi



