### PR TITLE
VZ-1596: Copy arbitrary WLS secrets when creating secrets

### DIFF
--- a/pkg/managed/secrets.go
+++ b/pkg/managed/secrets.go
@@ -177,6 +177,15 @@ func newSecrets(mbPair *types.ModelBindingPair, managedCluster *types.ManagedClu
 		}
 
 		secrets = append(secrets, secretObj)
+
+		// VZ-1596: Create secrets for configured list of arbitrary secrets
+		for _, secretName = range domain.Spec.Configuration.Secrets {
+			if secretObj, err = newSecret(secretName, namespace, kubeClientSet, nil, nil); err == nil {
+				secrets = append(secrets, secretObj)
+			} else {
+				zap.S().Errorf("Copying secret %s to namespace %s is giving error %v", secretName, namespace, err)
+			}
+		}
 	}
 
 	return secrets

--- a/pkg/managed/secrets.go
+++ b/pkg/managed/secrets.go
@@ -152,7 +152,7 @@ func newSecrets(mbPair *types.ModelBindingPair, managedCluster *types.ManagedClu
 	// Process WebLogic domain secrets
 	for _, domain := range managedCluster.WlsDomainCRs {
 		// Each WebLogic domain requires a runtime encryption secret that contains a randomly generated password.
-		// Note: we are assuming that each domain has DomainHomeSourceType is set to FromModel.
+		// Note: we are assuming that each domain has DomainHomeSourceType set to FromModel.
 
 		// Find the namespace for this domain in the binding placements
 		namespace, err := util.GetComponentNamespace(domain.Name, binding)

--- a/pkg/managed/secrets.go
+++ b/pkg/managed/secrets.go
@@ -149,9 +149,11 @@ func newSecrets(mbPair *types.ModelBindingPair, managedCluster *types.ManagedClu
 		}
 	}
 
-	// Each WebLogic domain requires a runtime encryption secret that contains a randomly generated password.
-	// Note: we are assuming that each domain has DomainHomeSourceType is set to FromModel.
+	// Process WebLogic domain secrets
 	for _, domain := range managedCluster.WlsDomainCRs {
+		// Each WebLogic domain requires a runtime encryption secret that contains a randomly generated password.
+		// Note: we are assuming that each domain has DomainHomeSourceType is set to FromModel.
+
 		// Find the namespace for this domain in the binding placements
 		namespace, err := util.GetComponentNamespace(domain.Name, binding)
 		if err != nil {

--- a/pkg/managed/secrets_test.go
+++ b/pkg/managed/secrets_test.go
@@ -73,7 +73,7 @@ func TestCreateSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got an error listing secrets: %v", err)
 	}
-	assert.Len(list.Items, 2, "expected exactly 2 Secrets")
+	assert.Len(list.Items, 4, "expected exactly 4 Secrets")
 	secretProperties = []SecretProperties{
 		{
 			name:      "test-wls-secret",
@@ -81,6 +81,14 @@ func TestCreateSecrets(t *testing.T) {
 		},
 		{
 			name:      "testMysqlSecret",
+			namespace: "test3",
+		},
+		{
+			name:      "arbitrary-secret-1",
+			namespace: "test3",
+		},
+		{
+			name:      "arbitrary-secret-2",
 			namespace: "test3",
 		},
 	}

--- a/pkg/testutil/testdata.go
+++ b/pkg/testutil/testdata.go
@@ -170,6 +170,18 @@ func GetManagedClusterConnection(clusterName string) *util.ManagedClusterConnect
 			Namespace: "default",
 		},
 	}, metav1.CreateOptions{})
+	clusterConnection.KubeClient.CoreV1().Secrets("default").Create(context.TODO(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "arbitrary-secret-1",
+			Namespace: "default",
+		},
+	}, metav1.CreateOptions{})
+	clusterConnection.KubeClient.CoreV1().Secrets("default").Create(context.TODO(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "arbitrary-secret-2",
+			Namespace: "default",
+		},
+	}, metav1.CreateOptions{})
 
 	clusterConnection.KubeClient.CoreV1().Services(IstioSystemNamespace).Create(context.TODO(),
 		&corev1.Service{

--- a/pkg/testutil/testdata/test_managed_cluster_1.yaml
+++ b/pkg/testutil/testdata/test_managed_cluster_1.yaml
@@ -86,6 +86,9 @@ WlsDomainCRs:
       configuration:
         Model:
           runtimeEncryptionSecret: test-wls-secret
+        secrets:
+          - arbitrary-secret-1
+          - arbitrary-secret-2
     status: {}
 GenericComponents:
   - name: test-generic


### PR DESCRIPTION
This addresses Verrazzano [issue 339](https://github.com/verrazzano/verrazzano/issues/339). We now copy any arbitrary Weblogic domain secrets when we're propagating secrets in the operator.

I'm not 100% confident that I did this correctly. Specifically I'm unsure if the namespacing is correct.