### PR TITLE
VZ-1667.  Fix filebeat processing of cert-manager/keycloak k8s labels fields

### DIFF
--- a/pkg/monitoring/constants.go
+++ b/pkg/monitoring/constants.go
@@ -15,6 +15,12 @@ const FilebeatConfigData = `filebeat.config:
     # Reload module configs as they change:
     reload.enabled: false
 name: ${NODENAME}
+filebeat.autodiscover:
+  providers:
+	- type: kubernetes
+	  hints.enabled: true
+	  labels.dedot: true
+	  annotations.dedot: true
 filebeat.inputs:
 - type: docker
   containers.ids:
@@ -104,6 +110,14 @@ const FilebeatIndexTemplate = `{
     }, {
       "string_fields" : {
         "match" : "*",
+        "match_mapping_type" : "string",
+        "mapping" : {
+          "type" : "text", "norms" : false,
+          "fields" : {
+            "keyword" : { "type": "keyword", "ignore_above": 256 }
+          }
+        }, {
+        "match" : "labels.app",
         "match_mapping_type" : "string",
         "mapping" : {
           "type" : "text", "norms" : false,

--- a/pkg/monitoring/constants.go
+++ b/pkg/monitoring/constants.go
@@ -116,14 +116,6 @@ const FilebeatIndexTemplate = `{
           "fields" : {
             "keyword" : { "type": "keyword", "ignore_above": 256 }
           }
-        }, {
-        "match" : "labels.app",
-        "match_mapping_type" : "string",
-        "mapping" : {
-          "type" : "text", "norms" : false,
-          "fields" : {
-            "keyword" : { "type": "keyword", "ignore_above": 256 }
-          }
         }
       }
     } ],

--- a/pkg/monitoring/constants.go
+++ b/pkg/monitoring/constants.go
@@ -17,10 +17,10 @@ const FilebeatConfigData = `filebeat.config:
 name: ${NODENAME}
 filebeat.autodiscover:
   providers:
-	- type: kubernetes
-	  hints.enabled: true
-	  labels.dedot: true
-	  annotations.dedot: true
+  - type: kubernetes
+    hints.enabled: true
+    labels.dedot: true
+    annotations.dedot: true
 filebeat.inputs:
 - type: docker
   containers.ids:


### PR DESCRIPTION
The cert-manager and keycloak pods use a dot-notated form for names in their labels, which is causing filebeat to create an object for such entries instead of a text field; Filebeat/ES support a notion of "dedot"-ing such fields to make flat names.

This change enables the dedot capability which seems to be allowing cert-manager and keycloak pod logs to be captured successfully, although we're still getting warnings/debug messages about collisions on the kubernetes.labels.app field.
