### PR TITLE
VZ-1596: Copy WLS domain secrets from model

### DIFF
--- a/pkg/wlsdom/wlsdomain.go
+++ b/pkg/wlsdom/wlsdomain.go
@@ -115,6 +115,7 @@ func CreateWlsDomainCR(namespace string, domainModel v1beta1v8o.VerrazzanoWebLog
 					ConfigMap:               datasourceModelConfigMap,
 					RuntimeEncryptionSecret: fmt.Sprintf("%s-runtime-encrypt-secret", domainUID),
 				},
+				Secrets: append(domainCRValues.Configuration.Secrets, dbSecrets...),
 			},
 			ServerStartPolicy: func() string {
 				if len(domainCRValues.ServerStartPolicy) > 0 {
@@ -162,10 +163,6 @@ func CreateWlsDomainCR(namespace string, domainModel v1beta1v8o.VerrazzanoWebLog
 			RestartVersion: domainCRValues.RestartVersion,
 		},
 		Status: v8weblogic.DomainStatus{},
-	}
-
-	if len(dbSecrets) > 0 {
-		domainCR.Spec.Configuration.Secrets = dbSecrets
 	}
 
 	// ConfigOverrides


### PR DESCRIPTION
This is the second PR to address https://github.com/verrazzano/verrazzano/issues/339. We were only copying DB secrets and this fix also copies domain secrets specified in the model.

I added unit tests but we should probably add integration tests for this at some point. I'll create a ticket to track that.

I also tested manually and confirmed that secrets are copied correctly to the target namespace.