### PR TITLE
WLS fluentd sidecar should use right VMI

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -37,6 +37,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+var LookupEnvFunc = os.LookupEnv
+
 // ManagedClusterConnection maintains the connection details to a ManagedCluster.
 type ManagedClusterConnection struct {
 	KubeClient                  kubernetes.Interface
@@ -269,7 +271,7 @@ func GetComponentNamespace(componentName string, binding *v1beta1v8o.VerrazzanoB
 // SharedVMIDefault return true if the env var SHARED_VMI_DEFAULT is true; this may be overridden by an app binding (future)
 func SharedVMIDefault() bool {
 	useSharedVMI := false
-	envValue, present := os.LookupEnv(sharedVMIDefault)
+	envValue, present := LookupEnvFunc(sharedVMIDefault)
 	if present {
 		zap.S().Debugf("Env var %s = %s", sharedVMIDefault, envValue)
 		value, err := strconv.ParseBool(envValue)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -37,6 +37,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// LookupEnvFunc is the function used to lookup env vars - it is made available here so that tests
+// can override it rather than setting env vars
 var LookupEnvFunc = os.LookupEnv
 
 // ManagedClusterConnection maintains the connection details to a ManagedCluster.

--- a/pkg/wlsdom/fluentd.go
+++ b/pkg/wlsdom/fluentd.go
@@ -54,7 +54,7 @@ func createFluentdContainer(domainModel v1beta1v8o.VerrazzanoWebLogicDomain, mbP
 			},
 			{
 				Name:  "ELASTICSEARCH_HOST",
-				Value: fmt.Sprintf("vmi-%s-es-ingest.%s.svc.cluster.local", mbPair.Binding.Name, constants.VerrazzanoNamespace),
+				Value: fmt.Sprintf("vmi-%s-es-ingest.%s.svc.cluster.local", util.GetProfileBindingName(mbPair.Binding.Name), constants.VerrazzanoNamespace),
 			},
 			{
 				Name:  "ELASTICSEARCH_PORT",

--- a/pkg/wlsdom/wlsdomain_test.go
+++ b/pkg/wlsdom/wlsdomain_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +26,8 @@ func TestIntrospectorJobActiveDeadlineSecondsWithDefaultValue(t *testing.T) {
 	vzWeblogicDomain := createWeblogicDomainModel("testDomain", true)
 	mbPair := types.ModelBindingPair{
 		Binding: &vz.VerrazzanoBinding{
-			Spec: vz.VerrazzanoBindingSpec{},
+			Spec:       vz.VerrazzanoBindingSpec{},
+			ObjectMeta: metav1.ObjectMeta{Name: vzWeblogicDomain.Name},
 		},
 		VerrazzanoURI: "test.v8o.xyz.com",
 	}
@@ -43,7 +46,8 @@ func TestIntrospectorJobActiveDeadlineSecondsWithOverrideValue(t *testing.T) {
 	vzWeblogicDomain.DomainCRValues.Configuration.IntrospectorJobActiveDeadlineSeconds = 900
 	mbPair := types.ModelBindingPair{
 		Binding: &vz.VerrazzanoBinding{
-			Spec: vz.VerrazzanoBindingSpec{},
+			Spec:       vz.VerrazzanoBindingSpec{},
+			ObjectMeta: metav1.ObjectMeta{Name: vzWeblogicDomain.Name},
 		},
 		VerrazzanoURI: "test.v8o.xyz.com",
 	}
@@ -59,12 +63,12 @@ func TestFluentdEnabledDefault(t *testing.T) {
 	vzWeblogicDomain := createWeblogicDomainModel(domainName, true)
 	mbPair := types.ModelBindingPair{
 		Binding: &vz.VerrazzanoBinding{
-			Spec: vz.VerrazzanoBindingSpec{},
+			Spec:       vz.VerrazzanoBindingSpec{},
+			ObjectMeta: metav1.ObjectMeta{Name: domainName},
 		},
 		VerrazzanoURI: "test.v8o.xyz.com",
 	}
 	mbPair.Binding.Spec.WeblogicBindings = []vz.VerrazzanoWeblogicBinding{{Name: domainName}}
-	mbPair.Binding.Name = domainName
 	labels := make(map[string]string)
 
 	useSystemVmi := false
@@ -91,7 +95,8 @@ func TestDomainSecrets(t *testing.T) {
 	vzWeblogicDomain := createWeblogicDomainModel(domainName, true)
 	mbPair := types.ModelBindingPair{
 		Binding: &vz.VerrazzanoBinding{
-			Spec: vz.VerrazzanoBindingSpec{},
+			Spec:       vz.VerrazzanoBindingSpec{},
+			ObjectMeta: metav1.ObjectMeta{Name: domainName},
 		},
 		VerrazzanoURI: "test.v8o.xyz.com",
 	}
@@ -117,7 +122,8 @@ func TestDbSecrets(t *testing.T) {
 	vzWeblogicDomain := createWeblogicDomainModel(domainName, true)
 	mbPair := types.ModelBindingPair{
 		Binding: &vz.VerrazzanoBinding{
-			Spec: vz.VerrazzanoBindingSpec{},
+			Spec:       vz.VerrazzanoBindingSpec{},
+			ObjectMeta: metav1.ObjectMeta{Name: domainName},
 		},
 		VerrazzanoURI: "test.v8o.xyz.com",
 	}
@@ -139,7 +145,8 @@ func TestDomainSecretsWithDbSecrets(t *testing.T) {
 	vzWeblogicDomain := createWeblogicDomainModel(domainName, true)
 	mbPair := types.ModelBindingPair{
 		Binding: &vz.VerrazzanoBinding{
-			Spec: vz.VerrazzanoBindingSpec{},
+			Spec:       vz.VerrazzanoBindingSpec{},
+			ObjectMeta: metav1.ObjectMeta{Name: domainName},
 		},
 		VerrazzanoURI: "test.v8o.xyz.com",
 	}


### PR DESCRIPTION
If shared VMI is configured, the WLS fluentd sidecar should use that Elasticsearch host instead of looking for the binding ES host