### PR TITLE
Changes to instance api to include information for shared vmi

### DIFF
--- a/pkg/api/instance/instance.go
+++ b/pkg/api/instance/instance.go
@@ -29,7 +29,7 @@ type Instance struct {
 	KibanaURL        string `json:"kibanaUrl"`
 	GrafanaURL       string `json:"grafanaUrl"`
 	PrometheusURL    string `json:"prometheusUrl"`
-	IsUsingSharedVMI bool   `json:"IsUsingSharedVMI"`
+	IsUsingSharedVMI bool   `json:"isUsingSharedVMI"`
 }
 
 // This is global for the operator

--- a/pkg/api/instance/instance.go
+++ b/pkg/api/instance/instance.go
@@ -10,24 +10,26 @@ import (
 	"strings"
 
 	clusterPkg "github.com/verrazzano/verrazzano-operator/pkg/api/clusters"
+	"github.com/verrazzano/verrazzano-operator/pkg/util"
 	"go.uber.org/zap"
 )
 
 // Instance details of instance returned in API calls.
 type Instance struct {
-	ID            string `json:"id"`
-	Name          string `json:"name"`
-	MgmtCluster   string `json:"mgmtCluster"`
-	MgmtPlatform  string `json:"mgmtPlatform"`
-	Status        string `json:"status"`
-	Version       string `json:"version"`
-	KeyCloakURL   string `json:"keyCloakUrl"`
-	RancherURL    string `json:"rancherUrl"`
-	VzAPIURL      string `json:"vzApiUri"`
-	ElasticURL    string `json:"elasticUrl"`
-	KibanaURL     string `json:"kibanaUrl"`
-	GrafanaURL    string `json:"grafanaUrl"`
-	PrometheusURL string `json:"prometheusUrl"`
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	MgmtCluster      string `json:"mgmtCluster"`
+	MgmtPlatform     string `json:"mgmtPlatform"`
+	Status           string `json:"status"`
+	Version          string `json:"version"`
+	KeyCloakURL      string `json:"keyCloakUrl"`
+	RancherURL       string `json:"rancherUrl"`
+	VzAPIURL         string `json:"vzApiUri"`
+	ElasticURL       string `json:"elasticUrl"`
+	KibanaURL        string `json:"kibanaUrl"`
+	GrafanaURL       string `json:"grafanaUrl"`
+	PrometheusURL    string `json:"prometheusUrl"`
+	IsUsingSharedVMI bool   `json:"IsUsingSharedVMI"`
 }
 
 // This is global for the operator
@@ -59,19 +61,20 @@ func ReturnSingleInstance(w http.ResponseWriter, r *http.Request) {
 	}
 
 	instance := Instance{
-		ID:            "0",
-		Name:          GetVerrazzanoName(),
-		MgmtCluster:   mgmtCluster.Name,
-		MgmtPlatform:  mgmtCluster.Type,
-		Status:        mgmtCluster.Status,
-		Version:       getVersion(),
-		VzAPIURL:      deriveURL("api"),
-		RancherURL:    deriveURL("rancher"),
-		ElasticURL:    GetElasticURL(),
-		KibanaURL:     GetKibanaURL(),
-		GrafanaURL:    GetGrafanaURL(),
-		PrometheusURL: GetPrometheusURL(),
-		KeyCloakURL:   GetKeyCloakURL(),
+		ID:               "0",
+		Name:             GetVerrazzanoName(),
+		MgmtCluster:      mgmtCluster.Name,
+		MgmtPlatform:     mgmtCluster.Type,
+		Status:           mgmtCluster.Status,
+		Version:          getVersion(),
+		VzAPIURL:         deriveURL("api"),
+		RancherURL:       deriveURL("rancher"),
+		ElasticURL:       GetElasticURL(),
+		KibanaURL:        GetKibanaURL(),
+		GrafanaURL:       GetGrafanaURL(),
+		PrometheusURL:    GetPrometheusURL(),
+		KeyCloakURL:      GetKeyCloakURL(),
+		IsUsingSharedVMI: util.SharedVMIDefault(),
 	}
 
 	json.NewEncoder(w).Encode(instance)

--- a/pkg/api/instance/instance_test.go
+++ b/pkg/api/instance/instance_test.go
@@ -4,10 +4,23 @@
 package instance
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 
+	"github.com/verrazzano/verrazzano-operator/pkg/util"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano-crd-generator/pkg/apis/verrazzano/v1beta1"
+	"github.com/verrazzano/verrazzano-operator/pkg/api/clusters"
+	"github.com/verrazzano/verrazzano-operator/pkg/testutil"
+	"github.com/verrazzano/verrazzano-operator/pkg/testutilcontroller"
+	"github.com/verrazzano/verrazzano-operator/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 const urlTemplate = "https://%v.%v"
@@ -20,6 +33,8 @@ type uriTest struct {
 	testChangedURI bool
 	verrazzanoURI  string
 }
+
+var origLookupEnvFunc = util.LookupEnvFunc
 
 // Test KeyCloak Url
 func TestGetKeyCloakUrl(t *testing.T) {
@@ -107,4 +122,56 @@ func runURLTestWithExpectedPrefix(t *testing.T, tt uriTest, methodUnderTest func
 		//WHEN methodUnderTest is called, THEN assert the value changes as expected
 		assert.Equal(t, expectedURL, methodUnderTest(), "URL not as expected after changing Verrazzano URI")
 	}
+}
+
+func TestIsUsingSharedVMI(t *testing.T) {
+	var modelBindingPairs = map[string]*types.ModelBindingPair{
+		"test-pair-1": testutil.ReadModelBindingPair(
+			"../../testutil/testdata/test_model.yaml",
+			"../../testutil/testdata/test_binding.yaml",
+			"../../testutil/testdata/test_managed_cluster_1.yaml", "../../testutil/testdata/test_managed_cluster_2.yaml"),
+	}
+	// GIVEN empty model binding pairs, managed clusters and fake kubernetes clients.
+	var clients kubernetes.Interface = k8sfake.NewSimpleClientset()
+	managedClusters := []v1beta1.VerrazzanoManagedCluster{}
+	clusters.Init(testutilcontroller.NewControllerListers(&clients, managedClusters, &modelBindingPairs))
+	SetVerrazzanoURI(vzURI)
+
+	type args struct {
+		w http.ResponseWriter
+		r *http.Request
+	}
+	tests := []struct {
+		name             string
+		isUsingSharedVMI bool
+	}{
+		{
+			name:             "verifyIsUsingSharedVMIUnset",
+			isUsingSharedVMI: false,
+		},
+		{
+			name:             "verifyIsUsingSharedVMISet",
+			isUsingSharedVMI: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			var myInstance Instance
+			assert := assert.New(t)
+			resp := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/instance/0", nil)
+			util.LookupEnvFunc = func(key string) (string, bool) {
+				if key == "USE_SYSTEM_VMI" {
+					return strconv.FormatBool(tt.isUsingSharedVMI), true
+				}
+				return origLookupEnvFunc(key)
+			}
+			ReturnSingleInstance(resp, req)
+			assert.Equal(http.StatusOK, resp.Code, "expect the http return code to be http.StatusOk")
+			json.NewDecoder(resp.Body).Decode(&myInstance)
+			assert.Equal(tt.isUsingSharedVMI, myInstance.IsUsingSharedVMI, fmt.Sprintf("expect IsUsingSharedVMI in instance api response to be %v.", tt.isUsingSharedVMI))
+		})
+	}
+	defer func() { util.LookupEnvFunc = origLookupEnvFunc }()
 }


### PR DESCRIPTION
In case of shared/system vmi, the application telemetry links on console binding details page need to be same as system telemetry links on home page. This change to add a new field `IsUsingSharedVMI` to the instance api response to send the information about shared vmi being used or not to console. Corresponding UI changes in https://github.com/verrazzano/console/pull/40