### PR TITLE
Fix bug in Verrazzano operator which caused duplicate secrets to be sent to WKO

### DIFF
--- a/pkg/wlsdom/wlsdomain.go
+++ b/pkg/wlsdom/wlsdomain.go
@@ -232,4 +232,3 @@ func SliceUniqMap(s []string) []string {
 	}
 	return s[:j]
 }
-

--- a/pkg/wlsdom/wlsdomain.go
+++ b/pkg/wlsdom/wlsdomain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package wlsdom

--- a/pkg/wlsdom/wlsdomain.go
+++ b/pkg/wlsdom/wlsdomain.go
@@ -115,7 +115,7 @@ func CreateWlsDomainCR(namespace string, domainModel v1beta1v8o.VerrazzanoWebLog
 					ConfigMap:               datasourceModelConfigMap,
 					RuntimeEncryptionSecret: fmt.Sprintf("%s-runtime-encrypt-secret", domainUID),
 				},
-				Secrets: append(domainCRValues.Configuration.Secrets, dbSecrets...),
+				Secrets: SliceUniqMap(append(domainCRValues.Configuration.Secrets, dbSecrets...)),
 			},
 			ServerStartPolicy: func() string {
 				if len(domainCRValues.ServerStartPolicy) > 0 {
@@ -215,3 +215,21 @@ func addFluentdConfig(serverPod *v8weblogic.ServerPod, domainModel v1beta1v8o.Ve
 	// Add fluentd volume mount
 	serverPod.VolumeMounts = append(serverPod.VolumeMounts, createFluentdVolumeMount("weblogic-domain-storage-volume"))
 }
+
+// SliceUniqMap will remove duplicate entries from the input
+// slice - essentially turning a "list" into a "set"
+// a "list" can have duplicate entries, a "set" cannot
+func SliceUniqMap(s []string) []string {
+	seen := make(map[string]struct{}, len(s))
+	j := 0
+	for _, v := range s {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		s[j] = v
+		j++
+	}
+	return s[:j]
+}
+

--- a/pkg/wlsdom/wlsdomain_test.go
+++ b/pkg/wlsdom/wlsdomain_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package wlsdom

--- a/pkg/wlsdom/wlsdomain_test.go
+++ b/pkg/wlsdom/wlsdomain_test.go
@@ -235,3 +235,28 @@ func checkFluentdEnv(t *testing.T, fluentdContainer corev1.Container, domainName
 		}
 	}
 }
+
+func TestSliceUniqMap(t *testing.T) {
+	input := []string{"ant", "cat", "dog", "ant", "anteater", "cow"}
+
+	output := SliceUniqMap(input)
+
+	if !(len(output) == 5 &&
+		contains(output, "ant") &&
+		contains(output, "cat") &&
+		contains(output, "dog") &&
+		contains(output, "anteater") &&
+		contains(output, "cow")) {
+		t.Errorf("SliceUniqMap was incorrect, got: %s, wanted %s", output, []string{"ant", "cat", "dog", "anteater", "cow"})
+	}
+}
+
+// Contains returns true if a slice element has an exact match to the input string
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
During testing of the todo app, we found a bug in the Verrazzano Operator.

In this line of code: 

https://github.com/verrazzano/verrazzano-operator/blob/89f29d969c5bab15def74da2d2834ae93c9abef7/pkg/wlsdom/wlsdomain.go#L118

`Secrets: append(domainCRValues.Configuration.Secrets, dbSecrets...),`

The `Secrets` slice needs to be deduplicated after this `append()` is done.  

If the WebLogic Kubernetes Operator encounters a list of secrets in a domain CR under `spec.configuration.secrets` with duplicate entries, it prints a validation error and refuses to start the domain.

My fix introduces code to remove duplicates from the list after the append, and unit tests for that new code. 

I have tested this manually, and am working on getting an acceptance test run now.