### PR TITLE
Fix Verrazzano system component logging when using Containerd container runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,8 +212,10 @@ endif
 ifdef JENKINS_URL
 	# Get the ip address of the container running the kube apiserver
 	# and update the kubeconfig file to point to that address, instead of localhost
-	sed -i -e "s|127.0.0.1.*|`docker inspect ${CLUSTER_NAME}-control-plane | jq '.[].NetworkSettings.IPAddress' | sed 's/"//g'`:6443|g" ${HOME}/.kube/config
+	sed -i -e "s|127.0.0.1.*|`docker inspect ${CLUSTER_NAME}-control-plane | jq '.[].NetworkSettings.Networks[].IPAddress' | sed 's/"//g'`:6443|g" ${HOME}/.kube/config
 	cat ${HOME}/.kube/config | grep server
+
+	$$(X=$$(docker inspect $$(docker ps | grep "jenkins-runner" | awk '{ print $$1 }') | jq '.[].NetworkSettings.Networks' | grep -q kind ; echo $$?); if [[ ! $$X -eq "0" ]]; then docker network connect kind $$(docker ps | grep "jenkins-runner" | awk '{ print $$1 }'); fi)
 endif
 
 .PHONY: delete-cluster

--- a/pkg/managed/configmaps.go
+++ b/pkg/managed/configmaps.go
@@ -18,7 +18,7 @@ import (
 )
 
 // CreateConfigMaps creates/updates config maps needed for each managed cluster.
-func CreateConfigMaps(vzSynMB *types.SyntheticModelBinding, filteredConnections map[string]*util.ManagedClusterConnection) error {
+func CreateConfigMaps(vzSynMB *types.SyntheticModelBinding, filteredConnections map[string]*util.ManagedClusterConnection, containerRuntime string) error {
 	zap.S().Debugf("Creating/updating ConfigMap for VerrazzanoBinding %s", vzSynMB.SynBinding.Name)
 
 	for clusterName, managedClusterObj := range vzSynMB.ManagedClusters {
@@ -27,7 +27,7 @@ func CreateConfigMaps(vzSynMB *types.SyntheticModelBinding, filteredConnections 
 		defer managedClusterConnection.Lock.RUnlock()
 
 		if vzSynMB.SynBinding.Name == constants.VmiSystemBindingName {
-			newConfigMaps, err := newConfigMaps(vzSynMB.SynBinding.Name, clusterName)
+			newConfigMaps, err := newConfigMaps(vzSynMB.SynBinding.Name, clusterName, containerRuntime)
 			if err != nil {
 				return err
 			}
@@ -102,9 +102,9 @@ func CleanupOrphanedConfigMaps(vzSynMB *types.SyntheticModelBinding, availableMa
 }
 
 // Constructs the necessary ConfigMaps for the specified ManagedCluster in the given VerrazzanoBinding
-func newConfigMaps(bindingName string, managedClusterName string) ([]*corev1.ConfigMap, error) {
+func newConfigMaps(bindingName string, managedClusterName string, containerRuntime string) ([]*corev1.ConfigMap, error) {
 	var configMaps []*corev1.ConfigMap
-	configMapsLogging := monitoring.LoggingConfigMaps(managedClusterName)
+	configMapsLogging := monitoring.LoggingConfigMaps(managedClusterName, containerRuntime)
 	for _, configMap := range configMapsLogging {
 		configMaps = append(configMaps, configMap)
 	}

--- a/pkg/managed/configmaps_test.go
+++ b/pkg/managed/configmaps_test.go
@@ -20,7 +20,7 @@ func TestCreateConfigMaps(t *testing.T) {
 	clusterConnections := testutil.GetManagedClusterConnections()
 	clusterConnection := clusterConnections["cluster1"]
 
-	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections)
+	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections, "docker://19.3.11")
 	if err != nil {
 		t.Fatalf("can't create config maps: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestCreateConfigMapsUpdateMap(t *testing.T) {
 	clusterConnections := testutil.GetManagedClusterConnections()
 	clusterConnection := clusterConnections["cluster1"]
 
-	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections)
+	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections, "docker://19.3.11")
 	if err != nil {
 		t.Fatalf("can't create config maps: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestCreateConfigMapsUpdateMap(t *testing.T) {
 	cm["bar"] = "ddd"
 	cm["biz"] = "ccc"
 
-	err = CreateConfigMaps(SyntheticModelBinding, clusterConnections)
+	err = CreateConfigMaps(SyntheticModelBinding, clusterConnections, "docker://19.3.11")
 	if err != nil {
 		t.Fatalf("can't create config maps: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestCreateConfigMapsVmiSystem(t *testing.T) {
 	clusterConnection := clusterConnections[clusterName]
 
 	SyntheticModelBinding.SynBinding.Name = constants.VmiSystemBindingName
-	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections)
+	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections, "docker://19.3.11")
 	if err != nil {
 		t.Fatalf("can't create config maps: %v", err)
 	}
@@ -116,14 +116,14 @@ func TestCreateConfigMapsVmiSystem(t *testing.T) {
 	if err != nil {
 		t.Errorf("can't get configmap: %v", err)
 	}
-	assert.Equal(monitoring.FilebeatConfigData, cm.Data["filebeat.yml"])
+	assert.Equal(monitoring.FilebeatConfigDataDocker, cm.Data["filebeat.yml"])
 	assert.Equal(filebeatLabels, cm.Labels)
 
 	cm, err = clusterConnection.KubeClient.CoreV1().ConfigMaps("logging").Get(context.TODO(), "filebeat-inputs", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("can't get configmap: %v", err)
 	}
-	assert.Equal(monitoring.FilebeatInputData, cm.Data["kubernetes.yml"])
+	assert.Equal(monitoring.FilebeatInputDataDocker, cm.Data["kubernetes.yml"])
 	assert.Equal(filebeatLabels, cm.Labels)
 
 	cm, err = clusterConnection.KubeClient.CoreV1().ConfigMaps("logging").Get(context.TODO(), "journalbeat-index-config", metav1.GetOptions{})

--- a/pkg/managed/daemonsets.go
+++ b/pkg/managed/daemonsets.go
@@ -17,7 +17,7 @@ import (
 )
 
 // CreateDaemonSets creates/updates daemon sets needed for each managed cluster.
-func CreateDaemonSets(vzSynMB *types.SyntheticModelBinding, filteredConnections map[string]*util.ManagedClusterConnection, verrazzanoURI string) error {
+func CreateDaemonSets(vzSynMB *types.SyntheticModelBinding, filteredConnections map[string]*util.ManagedClusterConnection, verrazzanoURI string, containerRuntime string) error {
 	zap.S().Debugf("Creating/updating daemonset for VerrazzanoBinding %s", vzSynMB.SynBinding.Name)
 
 	// If binding is not System binding, skip creating Daemon sets
@@ -33,7 +33,7 @@ func CreateDaemonSets(vzSynMB *types.SyntheticModelBinding, filteredConnections 
 		defer managedClusterConnection.Lock.RUnlock()
 
 		// Construct DaemonSet for each ManagedCluster
-		newDaemonSets, err := newDaemonSet(clusterName, verrazzanoURI)
+		newDaemonSets, err := newDaemonSet(clusterName, verrazzanoURI, containerRuntime)
 		if err != nil {
 			return err
 		}
@@ -64,8 +64,8 @@ func CreateDaemonSets(vzSynMB *types.SyntheticModelBinding, filteredConnections 
 }
 
 // Constructs the necessary Daemonset for the specified ManagedCluster
-func newDaemonSet(managedClusterName string, verrazzanoURI string) ([]*appsv1.DaemonSet, error) {
+func newDaemonSet(managedClusterName string, verrazzanoURI string, containerRuntime string) ([]*appsv1.DaemonSet, error) {
 	var daemonSets []*appsv1.DaemonSet
-	daemonSets = monitoring.SystemDaemonSets(managedClusterName, verrazzanoURI)
+	daemonSets = monitoring.SystemDaemonSets(managedClusterName, verrazzanoURI, containerRuntime)
 	return daemonSets, nil
 }

--- a/pkg/managed/daemonsets_test.go
+++ b/pkg/managed/daemonsets_test.go
@@ -19,7 +19,8 @@ import (
 const verrazzanoURI = "test"
 const clusterName1 = "cluster1"
 
-// TestCreateDaemonSetsVmiSystem tests the creation of daemon sets when the binding name is 'system'
+// TestCreateDaemonSetsVmiSystem tests the creation of daemon sets when the binding name is 'system' and the container
+// runtime is Docker.
 // GIVEN a cluster which does not have any daemon sets
 //  WHEN I call CreateDaemonSets with a binding named 'system'
 //  THEN there should be a set of system daemon sets created for the specified ManagedCluster
@@ -32,11 +33,32 @@ func TestCreateDaemonSetsVmiSystem(t *testing.T) {
 
 	VzSystemInfo.SynBinding.Name = constants.VmiSystemBindingName
 
-	err := CreateDaemonSets(VzSystemInfo, clusterConnections, verrazzanoURI)
+	err := CreateDaemonSets(VzSystemInfo, clusterConnections, verrazzanoURI, "docker://19.3.11")
 	assert.Nil(err, "got an error from CreateDaemonSets: %v", err)
 
 	// assert that the daemon sets in the given cluster match the expected daemon sets
-	assertExpectedDaemonSets(t, clusterConnection, monitoring.SystemDaemonSets(clusterName1, verrazzanoURI))
+	assertExpectedDaemonSets(t, clusterConnection, monitoring.SystemDaemonSets(clusterName1, verrazzanoURI, "docker://19.3.11"))
+}
+
+// TestCreateDaemonSetsVmiSystem tests the creation of daemon sets when the binding name is 'system' and the container
+// runtime is Containerd.
+// GIVEN a cluster which does not have any daemon sets
+//  WHEN I call CreateDaemonSets with a binding named 'system'
+//  THEN there should be a set of system daemon sets created for the specified ManagedCluster
+func TestCreateDaemonSetsVmiSystemContainerd(t *testing.T) {
+	assert := assert.New(t)
+
+	VzSystemInfo := testutil.GetSyntheticModelBinding()
+	clusterConnections := testutil.GetManagedClusterConnections()
+	clusterConnection := clusterConnections[clusterName1]
+
+	VzSystemInfo.SynBinding.Name = constants.VmiSystemBindingName
+
+	err := CreateDaemonSets(VzSystemInfo, clusterConnections, verrazzanoURI, "containerd://1.4.0")
+	assert.Nil(err, "got an error from CreateDaemonSets: %v", err)
+
+	// assert that the daemon sets in the given cluster match the expected daemon sets
+	assertExpectedDaemonSets(t, clusterConnection, monitoring.SystemDaemonSets(clusterName1, verrazzanoURI, "containerd://1.4.0"))
 }
 
 // TestCreateDaemonSetsUpdateExistingSet tests that an existing daemon set will be properly updated
@@ -62,11 +84,11 @@ func TestCreateDaemonSetsUpdateExistingSet(t *testing.T) {
 	_, err := clusterConnection.KubeClient.AppsV1().DaemonSets("logging").Create(context.TODO(), &ds, metav1.CreateOptions{})
 	assert.Nil(err, "can't create daemon sets: %v", err)
 
-	err = CreateDaemonSets(VzSystemInfo, clusterConnections, verrazzanoURI)
+	err = CreateDaemonSets(VzSystemInfo, clusterConnections, verrazzanoURI, "docker://19.3.11")
 	assert.Nil(err, "got an error from CreateDaemonSets: %v", err)
 
 	// assert that the daemon sets in the given cluster match the expected daemon sets
-	assertExpectedDaemonSets(t, clusterConnection, monitoring.SystemDaemonSets(clusterName1, verrazzanoURI))
+	assertExpectedDaemonSets(t, clusterConnection, monitoring.SystemDaemonSets(clusterName1, verrazzanoURI, "docker://19.3.11"))
 }
 
 // assertExpectedDaemonSets asserts that the daemon sets in the given cluster match the expected daemon sets

--- a/pkg/monitoring/configmaps_test.go
+++ b/pkg/monitoring/configmaps_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package monitoring
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestLoggingConfigMaps(t *testing.T) {
+func TestLoggingConfigMapsDocker(t *testing.T) {
 	assert := assert.New(t)
 
 	const clusterName = "cluster1"
@@ -36,13 +36,13 @@ func TestLoggingConfigMaps(t *testing.T) {
 			Name:      "filebeat-config",
 			Namespace: constants.LoggingNamespace,
 			Labels:    filebeatLabels},
-			Data: map[string]string{"filebeat.yml": FilebeatConfigData, "es-index-template.json": FilebeatIndexTemplate},
+			Data: map[string]string{"filebeat.yml": FilebeatConfigDataDocker, "es-index-template.json": FilebeatIndexTemplate},
 		},
 		"filebeat-inputs": {ObjectMeta: metav1.ObjectMeta{
 			Name:      "filebeat-config",
 			Namespace: constants.LoggingNamespace,
 			Labels:    filebeatLabels},
-			Data: map[string]string{"kubernetes.yml": FilebeatInputData},
+			Data: map[string]string{"kubernetes.yml": FilebeatInputDataDocker},
 		},
 		"journalbeat-index-config": {ObjectMeta: metav1.ObjectMeta{
 			Name:      "journalbeat-index-config",
@@ -57,7 +57,73 @@ func TestLoggingConfigMaps(t *testing.T) {
 			Data: map[string]string{"journalbeat.yml": JournalbeatConfigData},
 		},
 	}
-	cmaps := LoggingConfigMaps(clusterName)
+	cmaps := LoggingConfigMaps(clusterName, "docker://19.3.11")
+	assert.NotNilf(cmaps, "LoggingConfigMaps return nil")
+	for _, v := range cmaps {
+		tv, ok := testMap[v.Name]
+		assert.Truef(ok, "LoggingConfigMaps returned unexpected entry &v", v.Name)
+		assert.Equal(tv.Namespace, v.Namespace)
+		assert.Equal(tv.Labels, v.Labels)
+		for dk, dv := range v.Data {
+			tdata, ok := tv.Data[dk]
+			assert.Truef(ok, "Configmap data is missing for entry &v", v.Name)
+			assert.Equal(tdata, dv)
+		}
+		delete(testMap, v.Name)
+	}
+	// All of the entries in the testMap should have been removed
+	assert.Equalf(0, len(testMap), "LoggingConfigMaps did not return all of the entries")
+	for _, v := range testMap {
+		assert.Emptyf(v, "Configmap entry %v missing")
+	}
+}
+
+func TestLoggingConfigMapsContainerd(t *testing.T) {
+	assert := assert.New(t)
+
+	const clusterName = "cluster1"
+	filebeatLabels := GetFilebeatLabels(clusterName)
+	journalbeatLabels := GetJournalbeatLabels(clusterName)
+
+	testMap := map[string]corev1.ConfigMap{
+		"index-config": {ObjectMeta: metav1.ObjectMeta{
+			Name:      "index-config",
+			Namespace: constants.LoggingNamespace,
+			Labels:    filebeatLabels},
+			Data: map[string]string{"index_name": "vmo-demo-filebeat"},
+		},
+		"filebeat-index-config": {ObjectMeta: metav1.ObjectMeta{
+			Name:      "filebeat-index-config",
+			Namespace: constants.LoggingNamespace,
+			Labels:    filebeatLabels},
+			Data: map[string]string{"filebeat-index-name": "vmo-" + clusterName + "-filebeat-%{+yyyy.MM.dd}"},
+		},
+		"filebeat-config": {ObjectMeta: metav1.ObjectMeta{
+			Name:      "filebeat-config",
+			Namespace: constants.LoggingNamespace,
+			Labels:    filebeatLabels},
+			Data: map[string]string{"filebeat.yml": FilebeatConfigDataContainerd, "es-index-template.json": FilebeatIndexTemplate},
+		},
+		"filebeat-inputs": {ObjectMeta: metav1.ObjectMeta{
+			Name:      "filebeat-config",
+			Namespace: constants.LoggingNamespace,
+			Labels:    filebeatLabels},
+			Data: map[string]string{"kubernetes.yml": FilebeatInputDataContainerd},
+		},
+		"journalbeat-index-config": {ObjectMeta: metav1.ObjectMeta{
+			Name:      "journalbeat-index-config",
+			Namespace: constants.LoggingNamespace,
+			Labels:    journalbeatLabels},
+			Data: map[string]string{"journalbeat-index-name": "vmo-" + clusterName + "-journalbeat-%{+yyyy.MM.dd}"},
+		},
+		"journalbeat-config": {ObjectMeta: metav1.ObjectMeta{
+			Name:      "journalbeat-index-config",
+			Namespace: constants.LoggingNamespace,
+			Labels:    journalbeatLabels},
+			Data: map[string]string{"journalbeat.yml": JournalbeatConfigData},
+		},
+	}
+	cmaps := LoggingConfigMaps(clusterName, "containerd://1.4.0")
 	assert.NotNilf(cmaps, "LoggingConfigMaps return nil")
 	for _, v := range cmaps {
 		tv, ok := testMap[v.Name]

--- a/pkg/monitoring/daemonsets_test.go
+++ b/pkg/monitoring/daemonsets_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package monitoring
@@ -23,7 +23,7 @@ func TestCreateFilebeatDaemonSet(t *testing.T) {
 		constants.FilebeatName:     true,
 		constants.JournalbeatName:  true,
 		constants.NodeExporterName: true}
-	dsets := SystemDaemonSets(clusterName, uri)
+	dsets := SystemDaemonSets(clusterName, uri, "docker://19.3.11")
 	for _, v := range dsets {
 		switch v.Name {
 		case constants.FilebeatName:


### PR DESCRIPTION
Changes to support logging to Elasticsearach in a Kubernetes cluster with a Containerd container runtime.
Previously, Verrazzano system components only logged to Elasticsearch in a Docker environment. The paths to which the logs are written to by the Kubernetes log driver are different across container runtimes.