### PR TITLE
use nodeport instead of ingress address to access rancher at runtime.

### DIFF
--- a/pkg/managed/utils.go
+++ b/pkg/managed/utils.go
@@ -58,14 +58,16 @@ func setupHTTPResolve(cfg *restclient.Config) error {
 		}
 		parsedHost := urlObj.Host
 		host := util.GetRancherHost()
-		if host != "" && host != parsedHost {
+		port := util.GetRancherPort()
+		zap.S().Debugf("resolve address: %s:%s \n", host, port)
+		if host != "" && port != "" && host != parsedHost {
 			dialer := &net.Dialer{
 				Timeout:   30 * time.Second,
 				KeepAlive: 30 * time.Second,
 			}
 			cfg.Dial = func(ctx context.Context, network, addr string) (net.Conn, error) {
 				if addr == parsedHost+":443" {
-					addr = host + ":443"
+					addr = host + ":" + port
 					zap.S().Debugf("address modified from %s to %s \n", parsedHost+":443", addr)
 				}
 				return dialer.DialContext(ctx, network, addr)

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -155,7 +155,12 @@ func GetRancherURL() string {
 	return GetEnvFunc("rancherURL")
 }
 
-// GetRancherHost returns optional host name to use in host headers when accessing Rancher
+// GetRancherHost returns optional host to access Rancher
 func GetRancherHost() string {
 	return GetEnvFunc("rancherHost")
+}
+
+// GetRancherPort returns optional port to access Rancher
+func GetRancherPort() string {
+	return GetEnvFunc("rancherPort")
 }


### PR DESCRIPTION
follow the same idea as verrazzano/verrazzano#673.