### PR TITLE
fix filebeat in Kind

### DIFF
--- a/pkg/monitoring/constants.go
+++ b/pkg/monitoring/constants.go
@@ -85,7 +85,7 @@ name: ${NODENAME}
 filebeat.inputs:
 - type: log
   paths:
-    - /var/log/pods/**/*.log
+    - /var/lib/docker/containers/**/*.log
   processors:
   - decode_json_fields:
       fields: ["message"]
@@ -152,7 +152,7 @@ const FilebeatInputDataDocker = `- type: docker
 // FilebeatInputDataContainerd contains configuration used as inputs for Filebeats when using Containerd.
 const FilebeatInputDataContainerd = `- type: log
   paths:
-    - /var/log/pods/**/*.log
+    - /var/lib/docker/containers/**/*.log
 `
 
 // FilebeatIndexTemplate contains Elasticsearch index template for Filebeats.


### PR DESCRIPTION
Regardless the k8s runtime (containerd or docker), the logs directory is always mounted as /var/lib/docker/containers for filebeats pods. 