### PR TITLE
beats multicluster support

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1161,7 +1161,7 @@ func (m *monitoringPackage) DeletePomPusher(binding string, helper v8outil.Deplo
 }
 
 // MCRegistrationSecret - the name of the secret that contains the cluster registration information
-const MCRegistrationSecret = "verrazzano-cluster"
+const MCRegistrationSecret = "verrazzano-cluster-registration"
 
 // ClusterNameData - the field name in MCRegistrationSecret that contains this managed cluster's name
 const ClusterNameData = "managed-cluster-name"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1186,19 +1186,16 @@ const ElasticsearchPasswordData = "password"
 // cluster's Elasticsearch ca-bundle
 const ElasticsearchCABundleData = "ca-bundle"
 
-// getManagedClusterName returns the cluster name for a managed cluster, empty string otherwise
+// getClusterInfo returns the cluster info, including container runtime, and cluster name
+// as well as admin cluster Elasticsearch details if it is a managed cluster
 func (c *Controller) getClusterInfo() v8omonitoring.ClusterInfo {
-	managedClusterName := ""
-	clusterSecret, err := c.secrets.Get(MCRegistrationSecret)
-	if err == nil {
-		managedClusterName = string(clusterSecret.Data[ClusterNameData])
-	}
 	clusterInfo := v8omonitoring.ClusterInfo{
-		ContainerRuntime:   c.getContainerRuntime(),
-		ManagedClusterName: managedClusterName,
+		ContainerRuntime: c.getContainerRuntime(),
 	}
-	elasticsearchSecret, err := c.secrets.Get(ElasticsearchSecretName)
-	if err == nil {
+	clusterSecret, err1 := c.secrets.Get(MCRegistrationSecret)
+	elasticsearchSecret, err2 := c.secrets.Get(ElasticsearchSecretName)
+	if err1 == nil && err2 == nil {
+		clusterInfo.ManagedClusterName = string(clusterSecret.Data[ClusterNameData])
 		clusterInfo.ElasticsearchURL = string(elasticsearchSecret.Data[ElasticsearchURLData])
 		clusterInfo.ElasticsearchUsername = string(elasticsearchSecret.Data[ElasticsearchUsernameData])
 		clusterInfo.ElasticsearchPassword = string(elasticsearchSecret.Data[ElasticsearchPasswordData])

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -62,6 +62,8 @@ var testNode = v1.Node{Status: v1.NodeStatus{NodeInfo: v1.NodeSystemInfo{Contain
 var testNodes = []v1.Node{testNode}
 var testNodeList = v1.NodeList{Items: testNodes}
 
+var clusterInfoDocker = monitoring.ClusterInfo{ContainerRuntime: "docker://19.3.11"}
+
 // TestNewController tests creation of a Controller from kubeconfig.
 // This test mocks reading of the kubeconfig file
 // GIVEN a kubeconfig
@@ -130,12 +132,12 @@ func TestProcessManagedCluster(t *testing.T) {
 	managedMock.CreateNamespaces(vzSynMB, testFilteredConnections)
 	managedMock.CreateSecrets(vzSynMB, controller.managedClusterConnections, controller.kubeClientSet, controller.secrets)
 	managedMock.CreateServiceAccounts(vzSynMB.SynBinding.Name, vzSynMB.ImagePullSecrets, vzSynMB.ManagedClusters, testFilteredConnections)
-	managedMock.CreateConfigMaps(vzSynMB, testFilteredConnections, "docker://19.3.11")
+	managedMock.CreateConfigMaps(vzSynMB, testFilteredConnections, clusterInfoDocker)
 	managedMock.CreateClusterRoles(vzSynMB, testFilteredConnections)
 	managedMock.CreateClusterRoleBindings(vzSynMB, testFilteredConnections)
 	managedMock.CreateServices(vzSynMB, testFilteredConnections)
 	managedMock.CreateDeployments(vzSynMB, controller.managedClusterConnections, controller.verrazzanoURI, controller.secrets)
-	managedMock.CreateDaemonSets(vzSynMB, controller.managedClusterConnections, controller.verrazzanoURI, "docker://19.3.11")
+	managedMock.CreateDaemonSets(vzSynMB, controller.managedClusterConnections, controller.verrazzanoURI, clusterInfoDocker)
 	managedMock.SetupComplete()
 
 	// record expected 'util' interactions
@@ -240,12 +242,12 @@ func TestProcessApplicationBindingAdded(t *testing.T) {
 	managedMock.CreateNamespaces(SyntheticModelBinding, testFilteredConnections)
 	managedMock.CreateSecrets(SyntheticModelBinding, controller.managedClusterConnections, controller.kubeClientSet, controller.secrets)
 	managedMock.CreateServiceAccounts(SyntheticModelBinding.SynBinding.Name, SyntheticModelBinding.ImagePullSecrets, SyntheticModelBinding.ManagedClusters, testFilteredConnections)
-	managedMock.CreateConfigMaps(SyntheticModelBinding, testFilteredConnections, "docker://19.3.11")
+	managedMock.CreateConfigMaps(SyntheticModelBinding, testFilteredConnections, clusterInfoDocker)
 	managedMock.CreateClusterRoles(SyntheticModelBinding, testFilteredConnections)
 	managedMock.CreateClusterRoleBindings(SyntheticModelBinding, testFilteredConnections)
 	managedMock.CreateServices(SyntheticModelBinding, testFilteredConnections)
 	managedMock.CreateDeployments(SyntheticModelBinding, testFilteredConnections, controller.verrazzanoURI, controller.secrets)
-	managedMock.CreateDaemonSets(SyntheticModelBinding, testFilteredConnections, controller.verrazzanoURI, "docker://19.3.11")
+	managedMock.CreateDaemonSets(SyntheticModelBinding, testFilteredConnections, controller.verrazzanoURI, clusterInfoDocker)
 	managedMock.SetupComplete()
 
 	localMock := controller.local.(*testLocalPackage)
@@ -478,11 +480,11 @@ func (t *testManagedPackage) CreateServiceAccounts(bindingName string, imagePull
 	return nil
 }
 
-func (t *testManagedPackage) CreateConfigMaps(vzSynMB *types.SyntheticModelBinding, filteredConnections map[string]*util.ManagedClusterConnection, containerRuntime string) error {
+func (t *testManagedPackage) CreateConfigMaps(vzSynMB *types.SyntheticModelBinding, filteredConnections map[string]*util.ManagedClusterConnection, clusterInfo monitoring.ClusterInfo) error {
 	t.Record("CreateConfigMaps", map[string]interface{}{
 		"vzSynMB":             vzSynMB,
 		"filteredConnections": filteredConnections,
-		"containerRuntime":    containerRuntime})
+		"containerRuntime":    clusterInfo})
 	return nil
 }
 
@@ -545,12 +547,12 @@ func (t *testManagedPackage) UpdateIstioPrometheusConfigMaps(vzSynMB *types.Synt
 	return nil
 }
 
-func (t *testManagedPackage) CreateDaemonSets(vzSynMB *types.SyntheticModelBinding, availableManagedClusterConnections map[string]*util.ManagedClusterConnection, verrazzanoURI string, containerRuntime string) error {
+func (t *testManagedPackage) CreateDaemonSets(vzSynMB *types.SyntheticModelBinding, availableManagedClusterConnections map[string]*util.ManagedClusterConnection, verrazzanoURI string, clusterInfo monitoring.ClusterInfo) error {
 	t.Record("CreateDaemonSets", map[string]interface{}{
 		"vzSynMB":                            vzSynMB,
 		"availableManagedClusterConnections": availableManagedClusterConnections,
 		"verrazzanoURI":                      verrazzanoURI,
-		"containerRuntime":                   containerRuntime})
+		"containerRuntime":                   clusterInfo})
 	return nil
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -5,6 +5,8 @@ package controller
 
 import (
 	"context"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano-crd-generator/pkg/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano-crd-generator/pkg/client/clientset/versioned/fake"
@@ -23,7 +25,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
-	"testing"
 )
 
 var testClusterName = "test-cluster"
@@ -130,7 +131,7 @@ func TestProcessManagedCluster(t *testing.T) {
 	managedMock := controller.managed.(*testManagedPackage)
 	managedMock.BuildManagedClusterConnection(testSecretData, controller.stopCh)
 	managedMock.CreateNamespaces(vzSynMB, testFilteredConnections)
-	managedMock.CreateSecrets(vzSynMB, controller.managedClusterConnections, controller.kubeClientSet, controller.secrets)
+	managedMock.CreateSecrets(vzSynMB, controller.managedClusterConnections, controller.kubeClientSet, controller.secrets, clusterInfoDocker)
 	managedMock.CreateServiceAccounts(vzSynMB.SynBinding.Name, vzSynMB.ImagePullSecrets, vzSynMB.ManagedClusters, testFilteredConnections)
 	managedMock.CreateConfigMaps(vzSynMB, testFilteredConnections, clusterInfoDocker)
 	managedMock.CreateClusterRoles(vzSynMB, testFilteredConnections)
@@ -240,7 +241,7 @@ func TestProcessApplicationBindingAdded(t *testing.T) {
 	// record expected 'managed' interactions
 	managedMock := controller.managed.(*testManagedPackage)
 	managedMock.CreateNamespaces(SyntheticModelBinding, testFilteredConnections)
-	managedMock.CreateSecrets(SyntheticModelBinding, controller.managedClusterConnections, controller.kubeClientSet, controller.secrets)
+	managedMock.CreateSecrets(SyntheticModelBinding, controller.managedClusterConnections, controller.kubeClientSet, controller.secrets, clusterInfoDocker)
 	managedMock.CreateServiceAccounts(SyntheticModelBinding.SynBinding.Name, SyntheticModelBinding.ImagePullSecrets, SyntheticModelBinding.ManagedClusters, testFilteredConnections)
 	managedMock.CreateConfigMaps(SyntheticModelBinding, testFilteredConnections, clusterInfoDocker)
 	managedMock.CreateClusterRoles(SyntheticModelBinding, testFilteredConnections)
@@ -462,7 +463,7 @@ func (t *testManagedPackage) CreateNamespaces(vzSynMB *types.SyntheticModelBindi
 	return nil
 }
 
-func (t *testManagedPackage) CreateSecrets(vzSynMB *types.SyntheticModelBinding, availableManagedClusterConnections map[string]*util.ManagedClusterConnection, kubeClientSet kubernetes.Interface, sec monitoring.Secrets) error {
+func (t *testManagedPackage) CreateSecrets(vzSynMB *types.SyntheticModelBinding, availableManagedClusterConnections map[string]*util.ManagedClusterConnection, kubeClientSet kubernetes.Interface, sec monitoring.Secrets, clusterInfo monitoring.ClusterInfo) error {
 	t.Record("CreateSecrets", map[string]interface{}{
 		"vzSynMB":                            vzSynMB,
 		"availableManagedClusterConnections": availableManagedClusterConnections,
@@ -484,7 +485,7 @@ func (t *testManagedPackage) CreateConfigMaps(vzSynMB *types.SyntheticModelBindi
 	t.Record("CreateConfigMaps", map[string]interface{}{
 		"vzSynMB":             vzSynMB,
 		"filteredConnections": filteredConnections,
-		"containerRuntime":    clusterInfo})
+		"clusterInfo":         clusterInfo})
 	return nil
 }
 
@@ -552,7 +553,7 @@ func (t *testManagedPackage) CreateDaemonSets(vzSynMB *types.SyntheticModelBindi
 		"vzSynMB":                            vzSynMB,
 		"availableManagedClusterConnections": availableManagedClusterConnections,
 		"verrazzanoURI":                      verrazzanoURI,
-		"containerRuntime":                   clusterInfo})
+		"clusterInfo":                        clusterInfo})
 	return nil
 }
 

--- a/pkg/managed/configmaps.go
+++ b/pkg/managed/configmaps.go
@@ -18,7 +18,7 @@ import (
 )
 
 // CreateConfigMaps creates/updates config maps needed for each managed cluster.
-func CreateConfigMaps(vzSynMB *types.SyntheticModelBinding, filteredConnections map[string]*util.ManagedClusterConnection, containerRuntime string) error {
+func CreateConfigMaps(vzSynMB *types.SyntheticModelBinding, filteredConnections map[string]*util.ManagedClusterConnection, clusterInfo monitoring.ClusterInfo) error {
 	zap.S().Debugf("Creating/updating ConfigMap for VerrazzanoBinding %s", vzSynMB.SynBinding.Name)
 
 	for clusterName, managedClusterObj := range vzSynMB.ManagedClusters {
@@ -27,7 +27,7 @@ func CreateConfigMaps(vzSynMB *types.SyntheticModelBinding, filteredConnections 
 		defer managedClusterConnection.Lock.RUnlock()
 
 		if vzSynMB.SynBinding.Name == constants.VmiSystemBindingName {
-			newConfigMaps, err := newConfigMaps(vzSynMB.SynBinding.Name, clusterName, containerRuntime)
+			newConfigMaps, err := newConfigMaps(vzSynMB.SynBinding.Name, clusterName, clusterInfo)
 			if err != nil {
 				return err
 			}
@@ -102,9 +102,9 @@ func CleanupOrphanedConfigMaps(vzSynMB *types.SyntheticModelBinding, availableMa
 }
 
 // Constructs the necessary ConfigMaps for the specified ManagedCluster in the given VerrazzanoBinding
-func newConfigMaps(bindingName string, managedClusterName string, containerRuntime string) ([]*corev1.ConfigMap, error) {
+func newConfigMaps(bindingName string, managedClusterName string, clusterInfo monitoring.ClusterInfo) ([]*corev1.ConfigMap, error) {
 	var configMaps []*corev1.ConfigMap
-	configMapsLogging := monitoring.LoggingConfigMaps(managedClusterName, containerRuntime)
+	configMapsLogging := monitoring.LoggingConfigMaps(managedClusterName, clusterInfo)
 	for _, configMap := range configMapsLogging {
 		configMaps = append(configMaps, configMap)
 	}

--- a/pkg/managed/configmaps_test.go
+++ b/pkg/managed/configmaps_test.go
@@ -20,7 +20,7 @@ func TestCreateConfigMaps(t *testing.T) {
 	clusterConnections := testutil.GetManagedClusterConnections()
 	clusterConnection := clusterConnections["cluster1"]
 
-	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections, "docker://19.3.11")
+	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections, clusterInfoDocker)
 	if err != nil {
 		t.Fatalf("can't create config maps: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestCreateConfigMapsUpdateMap(t *testing.T) {
 	clusterConnections := testutil.GetManagedClusterConnections()
 	clusterConnection := clusterConnections["cluster1"]
 
-	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections, "docker://19.3.11")
+	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections, clusterInfoDocker)
 	if err != nil {
 		t.Fatalf("can't create config maps: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestCreateConfigMapsUpdateMap(t *testing.T) {
 	cm["bar"] = "ddd"
 	cm["biz"] = "ccc"
 
-	err = CreateConfigMaps(SyntheticModelBinding, clusterConnections, "docker://19.3.11")
+	err = CreateConfigMaps(SyntheticModelBinding, clusterConnections, clusterInfoDocker)
 	if err != nil {
 		t.Fatalf("can't create config maps: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestCreateConfigMapsVmiSystem(t *testing.T) {
 	clusterConnection := clusterConnections[clusterName]
 
 	SyntheticModelBinding.SynBinding.Name = constants.VmiSystemBindingName
-	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections, "docker://19.3.11")
+	err := CreateConfigMaps(SyntheticModelBinding, clusterConnections, clusterInfoDocker)
 	if err != nil {
 		t.Fatalf("can't create config maps: %v", err)
 	}

--- a/pkg/managed/daemonsets.go
+++ b/pkg/managed/daemonsets.go
@@ -17,7 +17,7 @@ import (
 )
 
 // CreateDaemonSets creates/updates daemon sets needed for each managed cluster.
-func CreateDaemonSets(vzSynMB *types.SyntheticModelBinding, filteredConnections map[string]*util.ManagedClusterConnection, verrazzanoURI string, containerRuntime string) error {
+func CreateDaemonSets(vzSynMB *types.SyntheticModelBinding, filteredConnections map[string]*util.ManagedClusterConnection, verrazzanoURI string, clusterInfo monitoring.ClusterInfo) error {
 	zap.S().Debugf("Creating/updating daemonset for VerrazzanoBinding %s", vzSynMB.SynBinding.Name)
 
 	// If binding is not System binding, skip creating Daemon sets
@@ -33,7 +33,7 @@ func CreateDaemonSets(vzSynMB *types.SyntheticModelBinding, filteredConnections 
 		defer managedClusterConnection.Lock.RUnlock()
 
 		// Construct DaemonSet for each ManagedCluster
-		newDaemonSets, err := newDaemonSet(clusterName, verrazzanoURI, containerRuntime)
+		newDaemonSets, err := newDaemonSet(clusterName, verrazzanoURI, clusterInfo)
 		if err != nil {
 			return err
 		}
@@ -64,8 +64,8 @@ func CreateDaemonSets(vzSynMB *types.SyntheticModelBinding, filteredConnections 
 }
 
 // Constructs the necessary Daemonset for the specified ManagedCluster
-func newDaemonSet(managedClusterName string, verrazzanoURI string, containerRuntime string) ([]*appsv1.DaemonSet, error) {
+func newDaemonSet(managedClusterName string, verrazzanoURI string, clusterInfo monitoring.ClusterInfo) ([]*appsv1.DaemonSet, error) {
 	var daemonSets []*appsv1.DaemonSet
-	daemonSets = monitoring.SystemDaemonSets(managedClusterName, verrazzanoURI, containerRuntime)
+	daemonSets = monitoring.SystemDaemonSets(managedClusterName, verrazzanoURI, clusterInfo)
 	return daemonSets, nil
 }

--- a/pkg/managed/daemonsets_test.go
+++ b/pkg/managed/daemonsets_test.go
@@ -19,6 +19,9 @@ import (
 const verrazzanoURI = "test"
 const clusterName1 = "cluster1"
 
+var clusterInfoDocker = monitoring.ClusterInfo{ContainerRuntime: "docker://19.3.11"}
+var clusterInfoContainerd = monitoring.ClusterInfo{ContainerRuntime: "containerd://1.4.0"}
+
 // TestCreateDaemonSetsVmiSystem tests the creation of daemon sets when the binding name is 'system' and the container
 // runtime is Docker.
 // GIVEN a cluster which does not have any daemon sets
@@ -33,11 +36,11 @@ func TestCreateDaemonSetsVmiSystem(t *testing.T) {
 
 	VzSystemInfo.SynBinding.Name = constants.VmiSystemBindingName
 
-	err := CreateDaemonSets(VzSystemInfo, clusterConnections, verrazzanoURI, "docker://19.3.11")
+	err := CreateDaemonSets(VzSystemInfo, clusterConnections, verrazzanoURI, clusterInfoDocker)
 	assert.Nil(err, "got an error from CreateDaemonSets: %v", err)
 
 	// assert that the daemon sets in the given cluster match the expected daemon sets
-	assertExpectedDaemonSets(t, clusterConnection, monitoring.SystemDaemonSets(clusterName1, verrazzanoURI, "docker://19.3.11"))
+	assertExpectedDaemonSets(t, clusterConnection, monitoring.SystemDaemonSets(clusterName1, verrazzanoURI, clusterInfoDocker))
 }
 
 // TestCreateDaemonSetsVmiSystem tests the creation of daemon sets when the binding name is 'system' and the container
@@ -54,11 +57,11 @@ func TestCreateDaemonSetsVmiSystemContainerd(t *testing.T) {
 
 	VzSystemInfo.SynBinding.Name = constants.VmiSystemBindingName
 
-	err := CreateDaemonSets(VzSystemInfo, clusterConnections, verrazzanoURI, "containerd://1.4.0")
+	err := CreateDaemonSets(VzSystemInfo, clusterConnections, verrazzanoURI, clusterInfoContainerd)
 	assert.Nil(err, "got an error from CreateDaemonSets: %v", err)
 
 	// assert that the daemon sets in the given cluster match the expected daemon sets
-	assertExpectedDaemonSets(t, clusterConnection, monitoring.SystemDaemonSets(clusterName1, verrazzanoURI, "containerd://1.4.0"))
+	assertExpectedDaemonSets(t, clusterConnection, monitoring.SystemDaemonSets(clusterName1, verrazzanoURI, clusterInfoContainerd))
 }
 
 // TestCreateDaemonSetsUpdateExistingSet tests that an existing daemon set will be properly updated
@@ -84,11 +87,11 @@ func TestCreateDaemonSetsUpdateExistingSet(t *testing.T) {
 	_, err := clusterConnection.KubeClient.AppsV1().DaemonSets("logging").Create(context.TODO(), &ds, metav1.CreateOptions{})
 	assert.Nil(err, "can't create daemon sets: %v", err)
 
-	err = CreateDaemonSets(VzSystemInfo, clusterConnections, verrazzanoURI, "docker://19.3.11")
+	err = CreateDaemonSets(VzSystemInfo, clusterConnections, verrazzanoURI, clusterInfoDocker)
 	assert.Nil(err, "got an error from CreateDaemonSets: %v", err)
 
 	// assert that the daemon sets in the given cluster match the expected daemon sets
-	assertExpectedDaemonSets(t, clusterConnection, monitoring.SystemDaemonSets(clusterName1, verrazzanoURI, "docker://19.3.11"))
+	assertExpectedDaemonSets(t, clusterConnection, monitoring.SystemDaemonSets(clusterName1, verrazzanoURI, clusterInfoDocker))
 }
 
 // assertExpectedDaemonSets asserts that the daemon sets in the given cluster match the expected daemon sets

--- a/pkg/managed/secrets.go
+++ b/pkg/managed/secrets.go
@@ -41,7 +41,7 @@ func CreateSecrets(vzSynMB *types.SyntheticModelBinding, availableManagedCluster
 
 		var secrets []*corev1.Secret
 		if vzSynMB.SynBinding.Name == constants.VmiSystemBindingName {
-			secrets = monitoring.GetSystemSecrets(sec)
+			secrets = monitoring.GetSystemSecrets(sec, clusterInfo)
 		} else {
 			secrets = newSecrets(vzSynMB, managedClusterObj, kubeClientSet)
 		}

--- a/pkg/managed/secrets.go
+++ b/pkg/managed/secrets.go
@@ -25,7 +25,7 @@ const wlsRuntimeEncryptionSecret = "wlsRuntimeEncryptionSecret"
 // CreateSecrets will go through a SyntheticModelBinding and find all of the secrets that are needed by
 // components, and it will then check if those secrets exist in the correct namespaces and clusters,
 // and then update or create them as needed
-func CreateSecrets(vzSynMB *types.SyntheticModelBinding, availableManagedClusterConnections map[string]*util.ManagedClusterConnection, kubeClientSet kubernetes.Interface, sec monitoring.Secrets) error {
+func CreateSecrets(vzSynMB *types.SyntheticModelBinding, availableManagedClusterConnections map[string]*util.ManagedClusterConnection, kubeClientSet kubernetes.Interface, sec monitoring.Secrets, clusterInfo monitoring.ClusterInfo) error {
 	zap.S().Debugf("Creating/updating Secrets for VerrazzanoBinding %s", vzSynMB.SynBinding.Name)
 
 	filteredConnections, err := GetFilteredConnections(vzSynMB, availableManagedClusterConnections)

--- a/pkg/monitoring/configmaps.go
+++ b/pkg/monitoring/configmaps.go
@@ -8,11 +8,10 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 // LoggingConfigMaps gets all the config maps needed by Filebeats and Journalbeats in all the managed cluster.
-func LoggingConfigMaps(managedClusterName string, containerRuntime string) []*corev1.ConfigMap {
+func LoggingConfigMaps(managedClusterName string, clusterInfo ClusterInfo) []*corev1.ConfigMap {
 	filebeatLabels := GetFilebeatLabels(managedClusterName)
 	journalbeatLabels := GetJournalbeatLabels(managedClusterName)
 	var configMaps []*corev1.ConfigMap
@@ -26,18 +25,12 @@ func LoggingConfigMaps(managedClusterName string, containerRuntime string) []*co
 		zap.S().Debugf("New logging config map %s is giving error %s", filebeatindexconfig.Name, err)
 	}
 
-	filebeatConfigData := FilebeatConfigDataDocker
-	filebeatInputData := FilebeatInputDataDocker
-	if strings.HasPrefix(containerRuntime, ContainerdContainerRuntimePrefix) {
-		filebeatConfigData = FilebeatConfigDataContainerd
-		filebeatInputData = FilebeatInputDataContainerd
-	}
-	filebeatconfig, err := createLoggingConfigMap(constants.LoggingNamespace, "filebeat-config", "filebeat.yml", filebeatConfigData, filebeatLabels)
+	filebeatconfig, err := createLoggingConfigMap(constants.LoggingNamespace, "filebeat-config", "filebeat.yml", getFilebeatConfig(clusterInfo), filebeatLabels)
 	if err != nil {
 		zap.S().Debugf("New logging config map %s is giving error %s", filebeatconfig.Name, err)
 	}
 	filebeatconfig.Data["es-index-template.json"] = FilebeatIndexTemplate
-	filebeatinput, err := createLoggingConfigMap(constants.LoggingNamespace, "filebeat-inputs", "kubernetes.yml", filebeatInputData, filebeatLabels)
+	filebeatinput, err := createLoggingConfigMap(constants.LoggingNamespace, "filebeat-inputs", "kubernetes.yml", getFilebeatInput(clusterInfo), filebeatLabels)
 	if err != nil {
 		zap.S().Debugf("New logging config map %s is giving error %s", filebeatinput.Name, err)
 	}

--- a/pkg/monitoring/configmaps.go
+++ b/pkg/monitoring/configmaps.go
@@ -38,7 +38,7 @@ func LoggingConfigMaps(managedClusterName string, clusterInfo ClusterInfo) []*co
 	if err != nil {
 		zap.S().Debugf("New logging config map %s is giving error %s", journalbeatindexconfig.Name, err)
 	}
-	journalbeatconfig, err := createLoggingConfigMap(constants.LoggingNamespace, "journalbeat-config", "journalbeat.yml", JournalbeatConfigData, journalbeatLabels)
+	journalbeatconfig, err := createLoggingConfigMap(constants.LoggingNamespace, "journalbeat-config", "journalbeat.yml", getJournalbeatConfig(clusterInfo), journalbeatLabels)
 	if err != nil {
 		zap.S().Debugf("New logging config map %s is giving error %s", journalbeatconfig.Name, err)
 	}

--- a/pkg/monitoring/configmaps_test.go
+++ b/pkg/monitoring/configmaps_test.go
@@ -12,6 +12,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var clusterInfoDocker = ClusterInfo{ContainerRuntime: "docker://19.3.11"}
+var clusterInfoContainerd = ClusterInfo{ContainerRuntime: "containerd://1.4.0"}
+
 func TestLoggingConfigMapsDocker(t *testing.T) {
 	assert := assert.New(t)
 
@@ -57,7 +60,7 @@ func TestLoggingConfigMapsDocker(t *testing.T) {
 			Data: map[string]string{"journalbeat.yml": JournalbeatConfigData},
 		},
 	}
-	cmaps := LoggingConfigMaps(clusterName, "docker://19.3.11")
+	cmaps := LoggingConfigMaps(clusterName, clusterInfoDocker)
 	assert.NotNilf(cmaps, "LoggingConfigMaps return nil")
 	for _, v := range cmaps {
 		tv, ok := testMap[v.Name]
@@ -123,7 +126,7 @@ func TestLoggingConfigMapsContainerd(t *testing.T) {
 			Data: map[string]string{"journalbeat.yml": JournalbeatConfigData},
 		},
 	}
-	cmaps := LoggingConfigMaps(clusterName, "containerd://1.4.0")
+	cmaps := LoggingConfigMaps(clusterName, clusterInfoContainerd)
 	assert.NotNilf(cmaps, "LoggingConfigMaps return nil")
 	for _, v := range cmaps {
 		tv, ok := testMap[v.Name]

--- a/pkg/monitoring/constants.go
+++ b/pkg/monitoring/constants.go
@@ -37,8 +37,6 @@ filebeat.inputs:
 - type: docker
   containers.ids:
   - "*"
-  fields:
-    verrazzano.cluster.name: ${CLUSTER_NAME}
   processors:
   - decode_json_fields:
       fields: ["message"]
@@ -88,8 +86,6 @@ filebeat.inputs:
 - type: log
   paths:
     - /var/lib/docker/containers/**/*.log
-  fields:
-    verrazzano.cluster.name: ${CLUSTER_NAME}
   processors:
   - decode_json_fields:
       fields: ["message"]

--- a/pkg/monitoring/constants.go
+++ b/pkg/monitoring/constants.go
@@ -37,6 +37,8 @@ filebeat.inputs:
 - type: docker
   containers.ids:
   - "*"
+  fields:
+    verrazzano.cluster.name: ${CLUSTER_NAME}
   processors:
   - decode_json_fields:
       fields: ["message"]
@@ -86,6 +88,8 @@ filebeat.inputs:
 - type: log
   paths:
     - /var/lib/docker/containers/**/*.log
+  fields:
+    verrazzano.cluster.name: ${CLUSTER_NAME}
   processors:
   - decode_json_fields:
       fields: ["message"]

--- a/pkg/monitoring/constants.go
+++ b/pkg/monitoring/constants.go
@@ -9,11 +9,11 @@ const DockerContainerRuntimePrefix = "docker://"
 // ContainerdContainerRuntimePrefix is the Containerd prefix used in the container runtime string.
 const ContainerdContainerRuntimePrefix = "containerd://"
 
-// FilebeatVolumeDocker is the logging volume when using Docker
-const FilebeatVolumeDocker = "/var/lib/docker/containers"
+// FilebeatLogHostPathDocker is the logging volume when using Docker
+const FilebeatLogHostPathDocker = "/var/lib/docker/containers"
 
-// FilebeatVolumeContainerd is the logging volume when using Containerd
-const FilebeatVolumeContainerd = "/var/log/pods"
+// FilebeatLogHostPathContainerd is the logging volume when using Containerd
+const FilebeatLogHostPathContainerd = "/var/log/pods"
 
 // FilebeatConfigDataDocker contains configuration used by Filebeats with a Docker container runtime.
 const FilebeatConfigDataDocker = `filebeat.config:

--- a/pkg/monitoring/constants.go
+++ b/pkg/monitoring/constants.go
@@ -65,6 +65,7 @@ setup.template.json.name: "vmo-local-filebeat"
 setup.template.pattern: "vmo-local-filebeat-*"
 output.elasticsearch:
   hosts: ${ES_URL}
+  ssl.certificate_authorities: "/etc/filebeat/secret/ca-bundle"
   username: ${ES_USER}
   password: ${ES_PASSWORD}
   index: ${INDEX_NAME}
@@ -114,6 +115,7 @@ setup.template.json.name: "vmo-local-filebeat"
 setup.template.pattern: "vmo-local-filebeat-*"
 output.elasticsearch:
   hosts: ${ES_URL}
+  ssl.certificate_authorities: "/etc/filebeat/secret/ca-bundle"
   username: ${ES_USER}
   password: ${ES_PASSWORD}
   index: ${INDEX_NAME}
@@ -135,6 +137,7 @@ logging.to_files: false
 setup.template.enabled: false
 output.elasticsearch:
   hosts: ${ES_URL}
+  ssl.certificate_authorities: "/etc/journalbeat/secret/ca-bundle" 
   username: ${ES_USER}
   password: ${ES_PASSWORD}
   index: ${INDEX_NAME}

--- a/pkg/monitoring/constants.go
+++ b/pkg/monitoring/constants.go
@@ -65,7 +65,6 @@ setup.template.json.name: "vmo-local-filebeat"
 setup.template.pattern: "vmo-local-filebeat-*"
 output.elasticsearch:
   hosts: ${ES_URL}
-  ssl.certificate_authorities: "/etc/filebeat/secret/ca-bundle"
   username: ${ES_USER}
   password: ${ES_PASSWORD}
   index: ${INDEX_NAME}
@@ -115,7 +114,6 @@ setup.template.json.name: "vmo-local-filebeat"
 setup.template.pattern: "vmo-local-filebeat-*"
 output.elasticsearch:
   hosts: ${ES_URL}
-  ssl.certificate_authorities: "/etc/filebeat/secret/ca-bundle"
   username: ${ES_USER}
   password: ${ES_PASSWORD}
   index: ${INDEX_NAME}
@@ -137,7 +135,6 @@ logging.to_files: false
 setup.template.enabled: false
 output.elasticsearch:
   hosts: ${ES_URL}
-  ssl.certificate_authorities: "/etc/journalbeat/secret/ca-bundle" 
   username: ${ES_USER}
   password: ${ES_PASSWORD}
   index: ${INDEX_NAME}
@@ -205,3 +202,9 @@ const FilebeatIndexTemplate = `{
   }
 }
 `
+
+// FileBeatCABundleSetting contains ssl ca setting for filebeat elasticsearch output
+const FileBeatCABundleSetting = "  ssl.certificate_authorities: /etc/filebeat/secret/ca-bundle\n"
+
+// JournalBeatCABundleSetting contains ssl ca setting for journalbeat elasticsearch output
+const JournalBeatCABundleSetting = "  ssl.certificate_authorities: /etc/journalbeat/secret/ca-bundle\n"

--- a/pkg/monitoring/daemonsets.go
+++ b/pkg/monitoring/daemonsets.go
@@ -175,6 +175,10 @@ func createFilebeatDaemonSet(namespace string, name string, labels map[string]st
 										},
 									},
 								},
+								{
+									Name:  "CLUSTER_NAME",
+									Value: clusterInfo.ManagedClusterName,
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -366,6 +370,10 @@ func createJournalbeatDaemonSet(namespace string, name string, labels map[string
 											Key: "journalbeat-index-name",
 										},
 									},
+								},
+								{
+									Name:  "CLUSTER_NAME",
+									Value: clusterInfo.ManagedClusterName,
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{

--- a/pkg/monitoring/daemonsets_test.go
+++ b/pkg/monitoring/daemonsets_test.go
@@ -23,7 +23,7 @@ func TestCreateFilebeatDaemonSet(t *testing.T) {
 		constants.FilebeatName:     true,
 		constants.JournalbeatName:  true,
 		constants.NodeExporterName: true}
-	dsets := SystemDaemonSets(clusterName, uri, "docker://19.3.11")
+	dsets := SystemDaemonSets(clusterName, uri, clusterInfoContainerd)
 	for _, v := range dsets {
 		switch v.Name {
 		case constants.FilebeatName:
@@ -62,7 +62,7 @@ func validateFilebeatDaemonset(assert *assert.Assertions, v appsv1.DaemonSet, cl
 	assert.Equal(int32(0600), *v.Spec.Template.Spec.Volumes[0].VolumeSource.ConfigMap.DefaultMode)
 
 	assert.Equal("varlibdockercontainers", v.Spec.Template.Spec.Volumes[1].Name)
-	assert.Equal("/var/lib/docker/containers", v.Spec.Template.Spec.Volumes[1].VolumeSource.HostPath.Path)
+	assert.Equal(FilebeatLogHostPathContainerd, v.Spec.Template.Spec.Volumes[1].VolumeSource.HostPath.Path)
 
 	assert.Equal("data", v.Spec.Template.Spec.Volumes[2].Name)
 	assert.Equal("/var/lib/filebeat-data", v.Spec.Template.Spec.Volumes[2].VolumeSource.HostPath.Path)

--- a/pkg/monitoring/daemonsets_test.go
+++ b/pkg/monitoring/daemonsets_test.go
@@ -123,6 +123,9 @@ func validateFilebeatDaemonset(assert *assert.Assertions, v appsv1.DaemonSet, cl
 	assert.Equal("filebeat-index-name",
 		v.Spec.Template.Spec.Containers[0].Env[4].ValueFrom.ConfigMapKeyRef.Key)
 
+	assert.Equal("CLUSTER_NAME", v.Spec.Template.Spec.Containers[0].Env[5].Name)
+	assert.Equal("", v.Spec.Template.Spec.Containers[0].Env[5].Value)
+
 	// Volume mounts
 	assert.Equal("config", v.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
 	assert.True(v.Spec.Template.Spec.Containers[0].VolumeMounts[0].ReadOnly)
@@ -228,6 +231,9 @@ func validateJournalbeatDaemonset(assert *assert.Assertions, v appsv1.DaemonSet,
 		v.Spec.Template.Spec.Containers[0].Env[4].ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name)
 	assert.Equal(constants.JournalbeatName+"-index-name",
 		v.Spec.Template.Spec.Containers[0].Env[4].ValueFrom.ConfigMapKeyRef.Key)
+
+	assert.Equal("CLUSTER_NAME", v.Spec.Template.Spec.Containers[0].Env[5].Name)
+	assert.Equal("", v.Spec.Template.Spec.Containers[0].Env[5].Value)
 
 	// Volume mounts
 	assert.Equal("config", v.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)

--- a/pkg/monitoring/daemonsets_test.go
+++ b/pkg/monitoring/daemonsets_test.go
@@ -55,7 +55,7 @@ func validateFilebeatDaemonset(assert *assert.Assertions, v appsv1.DaemonSet, cl
 	assert.Equal(labels, v.Spec.Template.Labels)
 
 	// Volumes
-	assert.Lenf(v.Spec.Template.Spec.Volumes, 4, "Spec.Template.Spec.Volumes has wrong number of items")
+	assert.Lenf(v.Spec.Template.Spec.Volumes, 5, "Spec.Template.Spec.Volumes has wrong number of items")
 
 	assert.Equal("config", v.Spec.Template.Spec.Volumes[0].Name)
 	assert.Equal(v.Name+"-config", v.Spec.Template.Spec.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name)
@@ -71,7 +71,11 @@ func validateFilebeatDaemonset(assert *assert.Assertions, v appsv1.DaemonSet, cl
 	assert.Equal("inputs", v.Spec.Template.Spec.Volumes[3].Name)
 	assert.Equal("filebeat-inputs",
 		v.Spec.Template.Spec.Volumes[3].VolumeSource.ConfigMap.LocalObjectReference.Name)
-	assert.Equal(int32(0600), *v.Spec.Template.Spec.Volumes[0].VolumeSource.ConfigMap.DefaultMode)
+	assert.Equal(int32(0600), *v.Spec.Template.Spec.Volumes[3].VolumeSource.ConfigMap.DefaultMode)
+
+	assert.Equal("secret", v.Spec.Template.Spec.Volumes[4].Name)
+	assert.Equal("filebeat-secret",
+		v.Spec.Template.Spec.Volumes[4].VolumeSource.Secret.SecretName)
 
 	// Containers
 	assert.Lenf(v.Spec.Template.Spec.Containers, 1, "Spec.Template.Spec.Containers has wrong number of items")
@@ -113,14 +117,11 @@ func validateFilebeatDaemonset(assert *assert.Assertions, v appsv1.DaemonSet, cl
 		v.Spec.Template.Spec.Containers[0].Env[3].ValueFrom.SecretKeyRef.LocalObjectReference.Name)
 	assert.Equal("password", v.Spec.Template.Spec.Containers[0].Env[3].ValueFrom.SecretKeyRef.Key)
 
-	assert.Equal("ES_PORT", v.Spec.Template.Spec.Containers[0].Env[4].Name)
-	assert.Equal("9200", v.Spec.Template.Spec.Containers[0].Env[4].Value)
-
-	assert.Equal("INDEX_NAME", v.Spec.Template.Spec.Containers[0].Env[5].Name)
+	assert.Equal("INDEX_NAME", v.Spec.Template.Spec.Containers[0].Env[4].Name)
 	assert.Equal("filebeat-index-config",
-		v.Spec.Template.Spec.Containers[0].Env[5].ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name)
+		v.Spec.Template.Spec.Containers[0].Env[4].ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name)
 	assert.Equal("filebeat-index-name",
-		v.Spec.Template.Spec.Containers[0].Env[5].ValueFrom.ConfigMapKeyRef.Key)
+		v.Spec.Template.Spec.Containers[0].Env[4].ValueFrom.ConfigMapKeyRef.Key)
 
 	// Volume mounts
 	assert.Equal("config", v.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
@@ -138,6 +139,10 @@ func validateFilebeatDaemonset(assert *assert.Assertions, v appsv1.DaemonSet, cl
 	assert.True(v.Spec.Template.Spec.Containers[0].VolumeMounts[3].ReadOnly)
 	assert.Equal("/var/lib/docker/containers", v.Spec.Template.Spec.Containers[0].VolumeMounts[3].MountPath)
 
+	assert.Equal("secret", v.Spec.Template.Spec.Containers[0].VolumeMounts[4].Name)
+	assert.True(v.Spec.Template.Spec.Containers[0].VolumeMounts[4].ReadOnly)
+	assert.Equal("/etc/filebeat/secret", v.Spec.Template.Spec.Containers[0].VolumeMounts[4].MountPath)
+
 	assert.Equal(corev1.PullIfNotPresent, v.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 
 	assert.Nil(v.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
@@ -154,7 +159,7 @@ func validateJournalbeatDaemonset(assert *assert.Assertions, v appsv1.DaemonSet,
 	assert.Equal(labels, v.Spec.Template.Labels)
 
 	// Volumes
-	assert.Lenf(v.Spec.Template.Spec.Volumes, 5, "Spec.Template.Spec.Volumes has wrong number of items")
+	assert.Lenf(v.Spec.Template.Spec.Volumes, 6, "Spec.Template.Spec.Volumes has wrong number of items")
 
 	assert.Equal("config", v.Spec.Template.Spec.Volumes[0].Name)
 	assert.Equal(v.Name+"-config", v.Spec.Template.Spec.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name)
@@ -173,6 +178,10 @@ func validateJournalbeatDaemonset(assert *assert.Assertions, v appsv1.DaemonSet,
 	assert.Equal("data", v.Spec.Template.Spec.Volumes[4].Name)
 	assert.Equal("/var/lib/journalbeat-data", v.Spec.Template.Spec.Volumes[4].VolumeSource.HostPath.Path)
 	assert.Nil(v.Spec.Template.Spec.Volumes[4].VolumeSource.HostPath.Type)
+
+	assert.Equal("secret", v.Spec.Template.Spec.Volumes[5].Name)
+	assert.Equal("journalbeat-secret",
+		v.Spec.Template.Spec.Volumes[5].VolumeSource.Secret.SecretName)
 
 	// Containers
 	assert.Lenf(v.Spec.Template.Spec.Containers, 1, "Spec.Template.Spec.Containers has wrong number of items")
@@ -214,14 +223,11 @@ func validateJournalbeatDaemonset(assert *assert.Assertions, v appsv1.DaemonSet,
 		v.Spec.Template.Spec.Containers[0].Env[3].ValueFrom.SecretKeyRef.LocalObjectReference.Name)
 	assert.Equal("password", v.Spec.Template.Spec.Containers[0].Env[3].ValueFrom.SecretKeyRef.Key)
 
-	assert.Equal("ES_PORT", v.Spec.Template.Spec.Containers[0].Env[4].Name)
-	assert.Equal("9200", v.Spec.Template.Spec.Containers[0].Env[4].Value)
-
-	assert.Equal("INDEX_NAME", v.Spec.Template.Spec.Containers[0].Env[5].Name)
+	assert.Equal("INDEX_NAME", v.Spec.Template.Spec.Containers[0].Env[4].Name)
 	assert.Equal(constants.JournalbeatName+"-index-config",
-		v.Spec.Template.Spec.Containers[0].Env[5].ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name)
+		v.Spec.Template.Spec.Containers[0].Env[4].ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name)
 	assert.Equal(constants.JournalbeatName+"-index-name",
-		v.Spec.Template.Spec.Containers[0].Env[5].ValueFrom.ConfigMapKeyRef.Key)
+		v.Spec.Template.Spec.Containers[0].Env[4].ValueFrom.ConfigMapKeyRef.Key)
 
 	// Volume mounts
 	assert.Equal("config", v.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
@@ -242,6 +248,10 @@ func validateJournalbeatDaemonset(assert *assert.Assertions, v appsv1.DaemonSet,
 	assert.Equal("etc-machine-id", v.Spec.Template.Spec.Containers[0].VolumeMounts[4].Name)
 	assert.True(v.Spec.Template.Spec.Containers[0].VolumeMounts[4].ReadOnly)
 	assert.Equal("/etc/machine-id", v.Spec.Template.Spec.Containers[0].VolumeMounts[4].MountPath)
+
+	assert.Equal("secret", v.Spec.Template.Spec.Containers[0].VolumeMounts[5].Name)
+	assert.True(v.Spec.Template.Spec.Containers[0].VolumeMounts[5].ReadOnly)
+	assert.Equal("/etc/journalbeat/secret", v.Spec.Template.Spec.Containers[0].VolumeMounts[5].MountPath)
 
 	assert.Equal(corev1.PullIfNotPresent, v.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 

--- a/pkg/monitoring/deployment.go
+++ b/pkg/monitoring/deployment.go
@@ -20,7 +20,7 @@ func GetSystemDeployments(managedClusterName, verrazzanoURI string, labels map[s
 	var deployments []*appsv1.Deployment
 
 	if managedClusterName == "" {
-		return nil, errors.New("GetSystemDeployments ManagedClusterName parameter must not be empty")
+		return nil, errors.New("GetSystemDeployments managedClusterName parameter must not be empty")
 	}
 	if verrazzanoURI == "" {
 		return nil, errors.New("GetSystemDeployments verrazzanoURI parameter must not be empty")

--- a/pkg/monitoring/deployment.go
+++ b/pkg/monitoring/deployment.go
@@ -20,7 +20,7 @@ func GetSystemDeployments(managedClusterName, verrazzanoURI string, labels map[s
 	var deployments []*appsv1.Deployment
 
 	if managedClusterName == "" {
-		return nil, errors.New("GetSystemDeployments managedClusterName parameter must not be empty")
+		return nil, errors.New("GetSystemDeployments ManagedClusterName parameter must not be empty")
 	}
 	if verrazzanoURI == "" {
 		return nil, errors.New("GetSystemDeployments verrazzanoURI parameter must not be empty")

--- a/pkg/monitoring/utils.go
+++ b/pkg/monitoring/utils.go
@@ -68,10 +68,22 @@ type ClusterInfo struct {
 }
 
 func getFilebeatConfig(clusterInfo ClusterInfo) string {
+	config := FilebeatConfigDataDocker
 	if strings.HasPrefix(clusterInfo.ContainerRuntime, ContainerdContainerRuntimePrefix) {
-		return FilebeatConfigDataContainerd
+		config = FilebeatConfigDataContainerd
 	}
-	return FilebeatConfigDataDocker
+	if isManagedCluster(clusterInfo) && len(clusterInfo.ElasticsearchCABundle) > 0 {
+		config = config + FileBeatCABundleSetting
+	}
+	return config
+}
+
+func getJournalbeatConfig(clusterInfo ClusterInfo) string {
+	config := JournalbeatConfigData
+	if isManagedCluster(clusterInfo) && len(clusterInfo.ElasticsearchCABundle) > 0 {
+		config = config + JournalBeatCABundleSetting
+	}
+	return config
 }
 
 func getFilebeatInput(clusterInfo ClusterInfo) string {

--- a/pkg/monitoring/utils.go
+++ b/pkg/monitoring/utils.go
@@ -4,8 +4,9 @@
 package monitoring
 
 import (
-	"github.com/verrazzano/verrazzano-operator/pkg/constants"
 	"strings"
+
+	"github.com/verrazzano/verrazzano-operator/pkg/constants"
 )
 
 // GetMonitoringComponentLabels returns labels for a given monitoring component.
@@ -57,8 +58,12 @@ func GetNodeExporterLabels(managedClusterName string) map[string]string {
 
 // ClusterInfo has info like ContainerRuntime and managed cluster name
 type ClusterInfo struct {
-	ContainerRuntime   string
-	ManagedClusterName string
+	ContainerRuntime      string
+	ManagedClusterName    string
+	ElasticsearchURL      string
+	ElasticsearchUsername string
+	ElasticsearchPassword string
+	ElasticsearchCABundle []byte
 }
 
 func getFilebeatConfig(clusterInfo ClusterInfo) string {

--- a/pkg/monitoring/utils.go
+++ b/pkg/monitoring/utils.go
@@ -5,6 +5,7 @@ package monitoring
 
 import (
 	"github.com/verrazzano/verrazzano-operator/pkg/constants"
+	"strings"
 )
 
 // GetMonitoringComponentLabels returns labels for a given monitoring component.
@@ -52,4 +53,31 @@ func GetJournalbeatLabels(managedClusterName string) map[string]string {
 // GetNodeExporterLabels returns labels for Node Exporter.
 func GetNodeExporterLabels(managedClusterName string) map[string]string {
 	return map[string]string{constants.ServiceAppLabel: constants.NodeExporterName, constants.VerrazzanoBinding: constants.VmiSystemBindingName, constants.VerrazzanoCluster: managedClusterName}
+}
+
+// ClusterInfo has info like ContainerRuntime and managed cluster name
+type ClusterInfo struct {
+	ContainerRuntime   string
+	ManagedClusterName string
+}
+
+func getFilebeatConfig(clusterInfo ClusterInfo) string {
+	if strings.HasPrefix(clusterInfo.ContainerRuntime, ContainerdContainerRuntimePrefix) {
+		return FilebeatConfigDataContainerd
+	}
+	return FilebeatConfigDataDocker
+}
+
+func getFilebeatInput(clusterInfo ClusterInfo) string {
+	if strings.HasPrefix(clusterInfo.ContainerRuntime, ContainerdContainerRuntimePrefix) {
+		return FilebeatInputDataContainerd
+	}
+	return FilebeatInputDataDocker
+}
+
+func getFilebeatLogHostPath(clusterInfo ClusterInfo) string {
+	if strings.HasPrefix(clusterInfo.ContainerRuntime, ContainerdContainerRuntimePrefix) {
+		return FilebeatLogHostPathContainerd
+	}
+	return FilebeatLogHostPathDocker
 }

--- a/pkg/monitoring/utils.go
+++ b/pkg/monitoring/utils.go
@@ -69,7 +69,7 @@ type ClusterInfo struct {
 
 func getFilebeatConfig(clusterInfo ClusterInfo) string {
 	config := FilebeatConfigDataDocker
-	if strings.HasPrefix(clusterInfo.ContainerRuntime, ContainerdContainerRuntimePrefix) {
+	if isContainerRuntimeContainerd(clusterInfo) {
 		config = FilebeatConfigDataContainerd
 	}
 	if isManagedCluster(clusterInfo) && len(clusterInfo.ElasticsearchCABundle) > 0 {
@@ -86,18 +86,26 @@ func getJournalbeatConfig(clusterInfo ClusterInfo) string {
 	return config
 }
 
+// if the containerRuntime is "containerd", use log input
+// if the containerRuntime is "docker", use docker input
 func getFilebeatInput(clusterInfo ClusterInfo) string {
-	if strings.HasPrefix(clusterInfo.ContainerRuntime, ContainerdContainerRuntimePrefix) {
+	if isContainerRuntimeContainerd(clusterInfo) {
 		return FilebeatInputDataContainerd
 	}
 	return FilebeatInputDataDocker
 }
 
+// if the containerRuntime is "containerd", the host path for logs is /var/log/pods
+// if the containerRuntime is "docker", the host path for logs is /var/lib/docker/containers
 func getFilebeatLogHostPath(clusterInfo ClusterInfo) string {
-	if strings.HasPrefix(clusterInfo.ContainerRuntime, ContainerdContainerRuntimePrefix) {
+	if isContainerRuntimeContainerd(clusterInfo) {
 		return FilebeatLogHostPathContainerd
 	}
 	return FilebeatLogHostPathDocker
+}
+
+func isContainerRuntimeContainerd(clusterInfo ClusterInfo) bool {
+	return strings.HasPrefix(clusterInfo.ContainerRuntime, ContainerdContainerRuntimePrefix)
 }
 
 func isManagedCluster(clusterInfo ClusterInfo) bool {

--- a/pkg/monitoring/utils.go
+++ b/pkg/monitoring/utils.go
@@ -4,6 +4,7 @@
 package monitoring
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/verrazzano/verrazzano-operator/pkg/constants"
@@ -85,4 +86,18 @@ func getFilebeatLogHostPath(clusterInfo ClusterInfo) string {
 		return FilebeatLogHostPathContainerd
 	}
 	return FilebeatLogHostPathDocker
+}
+
+func isManagedCluster(clusterInfo ClusterInfo) bool {
+	if clusterInfo.ManagedClusterName != "" {
+		return true
+	}
+	return false
+}
+
+func getElasticsearchURL(clusterInfo ClusterInfo) string {
+	if isManagedCluster(clusterInfo) {
+		return clusterInfo.ElasticsearchURL
+	}
+	return fmt.Sprintf("http://vmi-system-es-ingest.%s.svc.cluster.local", constants.VerrazzanoNamespace)
 }

--- a/pkg/monitoring/utils_test.go
+++ b/pkg/monitoring/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package monitoring

--- a/pkg/monitoring/utils_test.go
+++ b/pkg/monitoring/utils_test.go
@@ -4,9 +4,10 @@
 package monitoring
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano-operator/pkg/constants"
-	"testing"
 )
 
 func TestGetMonitoringComponentLabels(t *testing.T) {
@@ -83,4 +84,60 @@ func TestGetNodeExporterLabels(t *testing.T) {
 		constants.VerrazzanoCluster: clusterName}
 
 	assert.Equal(expected, GetNodeExporterLabels(clusterName))
+}
+
+func Test_getFilebeatConfig(t *testing.T) {
+	// not a managed cluster
+	config := getFilebeatConfig(ClusterInfo{ContainerRuntime: "docker://123"})
+	assert.Equal(t, FilebeatConfigDataDocker, config, "expected filebeat config")
+	config = getFilebeatConfig(ClusterInfo{ContainerRuntime: "containerd://123", ManagedClusterName: ""})
+	assert.Equal(t, FilebeatConfigDataContainerd, config, "expected filebeat config")
+
+	// managed cluster, without ca bundle
+	config = getFilebeatConfig(ClusterInfo{ContainerRuntime: "docker://123", ManagedClusterName: "cluster1"})
+	assert.Equal(t, FilebeatConfigDataDocker, config, "expected filebeat config")
+	config = getFilebeatConfig(ClusterInfo{ContainerRuntime: "containerd://123", ManagedClusterName: "cluster1"})
+	assert.Equal(t, FilebeatConfigDataContainerd, config, "expected filebeat config")
+
+	// managed cluster, with ca bundle
+	config = getFilebeatConfig(ClusterInfo{ContainerRuntime: "docker://123", ManagedClusterName: "cluster1", ElasticsearchCABundle: []byte("testCABundle")})
+	assert.Equal(t, FilebeatConfigDataDocker+FileBeatCABundleSetting, config, "expected filebeat config")
+	config = getFilebeatConfig(ClusterInfo{ContainerRuntime: "containerd://123", ManagedClusterName: "cluster1", ElasticsearchCABundle: []byte("testCABundle")})
+	assert.Equal(t, FilebeatConfigDataContainerd+FileBeatCABundleSetting, config, "expected filebeat config")
+}
+
+func Test_getJournalbeatConfig(t *testing.T) {
+	// not a managed cluster
+	config := getJournalbeatConfig(ClusterInfo{})
+	assert.Equal(t, JournalbeatConfigData, config, "expected journalbeat config")
+
+	// managed cluster, without ca bundle
+	config = getJournalbeatConfig(ClusterInfo{ManagedClusterName: "cluster1"})
+	assert.Equal(t, JournalbeatConfigData, config, "expected journalbeat config")
+
+	// managed cluster, with ca bundle
+	config = getJournalbeatConfig(ClusterInfo{ManagedClusterName: "cluster1", ElasticsearchCABundle: []byte("testCABundle")})
+	assert.Equal(t, JournalbeatConfigData+JournalBeatCABundleSetting, config, "expected journalbeat config")
+}
+
+func Test_getElasticsearchURL(t *testing.T) {
+	testURL := "testURL"
+	url := getElasticsearchURL(ClusterInfo{ManagedClusterName: "", ElasticsearchURL: testURL})
+	assert.Equal(t, "http://vmi-system-es-ingest.verrazzano-system.svc.cluster.local", url, "expected elasticsearch url")
+	url = getElasticsearchURL(ClusterInfo{ManagedClusterName: "cluster1", ElasticsearchURL: testURL})
+	assert.Equal(t, testURL, url, "expected elasticsearch url")
+}
+
+func Test_getFilebeatInput(t *testing.T) {
+	input := getFilebeatInput(ClusterInfo{ContainerRuntime: "docker://123"})
+	assert.Equal(t, FilebeatInputDataDocker, input, "expected filebeat input")
+	input = getFilebeatInput(ClusterInfo{ContainerRuntime: "containerd://123"})
+	assert.Equal(t, FilebeatInputDataContainerd, input, "expected filebeat input")
+}
+
+func Test_getFilebeatLogHostPath(t *testing.T) {
+	path := getFilebeatLogHostPath(ClusterInfo{ContainerRuntime: "docker://123"})
+	assert.Equal(t, FilebeatLogHostPathDocker, path, "expected filebeat log host path")
+	path = getFilebeatLogHostPath(ClusterInfo{ContainerRuntime: "containerd://123"})
+	assert.Equal(t, FilebeatLogHostPathContainerd, path, "expected filebeat log host path")
 }


### PR DESCRIPTION
VO reads in multicluster information like cluster name and ES details from verrazzano cluster registration secrets to configure filebeat and journalbeat to send logs to the admin ES.
For standalone verrazzano where there is no cluster registration secrets, the beats are configured to log to the local ES.
