### PR TITLE
Set the replicas=0 when creating an instance of VerrazzanoMonitoringInstanceSpec

### DIFF
--- a/pkg/local/vmis.go
+++ b/pkg/local/vmis.go
@@ -119,7 +119,7 @@ func createInstance(binding *types.SyntheticBinding, verrazzanoURI string, enabl
 			AutoSecret:      true,
 			SecretsName:     constants.VmiSecretName,
 			CascadingDelete: true,
-			API: vmov1.API {Replicas: 0},
+			API:             vmov1.API{Replicas: 0},
 			Grafana: vmov1.Grafana{
 				Enabled:             util.GetGrafanaEnabled(),
 				Storage:             createStorageOption(util.GetGrafanaDataStorageSize(), enableMonitoringStorage),

--- a/pkg/local/vmis.go
+++ b/pkg/local/vmis.go
@@ -119,6 +119,7 @@ func createInstance(binding *types.SyntheticBinding, verrazzanoURI string, enabl
 			AutoSecret:      true,
 			SecretsName:     constants.VmiSecretName,
 			CascadingDelete: true,
+			API: vmov1.API {Replicas: 0},
 			Grafana: vmov1.Grafana{
 				Enabled:             util.GetGrafanaEnabled(),
 				Storage:             createStorageOption(util.GetGrafanaDataStorageSize(), enableMonitoringStorage),


### PR DESCRIPTION
This change sets the replica to 0 when creating a VerrazzanoMonitoringInstance. This change is the first step to remove the dependency on verrazzano-monitoring-instance-api. Removing the type VerrazzanoMonitoringInstanceSpec completely needs more investigation and effort.
