### PR TITLE
JIRA:VZ-2518 support istio injection for logging namespace

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -43,7 +43,7 @@ const VerrazzanoNamespace = VerrazzanoSystem
 // VerrazzanoOperatorServiceAccount name for Verrazzano operator service account
 const VerrazzanoOperatorServiceAccount = "verrazzano-operator"
 
-// IstioInjection indicates wheter istio sidecars should be injected into pods in given namespace
+// IstioInjection indicates whether istio sidecars should be injected into pods in given namespace
 const IstioInjection = "istio-injection"
 
 // Enabled indicates that injection is enabled

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -43,6 +43,12 @@ const VerrazzanoNamespace = VerrazzanoSystem
 // VerrazzanoOperatorServiceAccount name for Verrazzano operator service account
 const VerrazzanoOperatorServiceAccount = "verrazzano-operator"
 
+// IstioInjection indicates wheter istio sidecars should be injected into pods in given namespace
+const IstioInjection = "istio-injection"
+
+// Enabled indicates that injection is enabled
+const Enabled = "enabled"
+
 // ManifestFile file name for Verrazzano operator manifest
 const ManifestFile = "manifest.json"
 

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -58,7 +58,7 @@ type DeploymentHelper interface {
 
 // GetManagedBindingLabels returns binding labels for managed cluster.
 func GetManagedBindingLabels(binding *types.SyntheticBinding, managedClusterName string) map[string]string {
-	return map[string]string{constants.K8SAppLabel: constants.VerrazzanoGroup, constants.VerrazzanoBinding: binding.Name, constants.VerrazzanoCluster: managedClusterName, "istio-injection": "enabled"}
+	return map[string]string{constants.K8SAppLabel: constants.VerrazzanoGroup, constants.VerrazzanoBinding: binding.Name, constants.VerrazzanoCluster: managedClusterName, constants.IstioInjection: constants.Enabled}
 }
 
 // GetManagedLabelsNoBinding return labels for managed cluster with no binding.

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -58,7 +58,7 @@ type DeploymentHelper interface {
 
 // GetManagedBindingLabels returns binding labels for managed cluster.
 func GetManagedBindingLabels(binding *types.SyntheticBinding, managedClusterName string) map[string]string {
-	return map[string]string{constants.K8SAppLabel: constants.VerrazzanoGroup, constants.VerrazzanoBinding: binding.Name, constants.VerrazzanoCluster: managedClusterName, "istio-injection" : "enabled"}
+	return map[string]string{constants.K8SAppLabel: constants.VerrazzanoGroup, constants.VerrazzanoBinding: binding.Name, constants.VerrazzanoCluster: managedClusterName, "istio-injection": "enabled"}
 }
 
 // GetManagedLabelsNoBinding return labels for managed cluster with no binding.

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -58,7 +58,7 @@ type DeploymentHelper interface {
 
 // GetManagedBindingLabels returns binding labels for managed cluster.
 func GetManagedBindingLabels(binding *types.SyntheticBinding, managedClusterName string) map[string]string {
-	return map[string]string{constants.K8SAppLabel: constants.VerrazzanoGroup, constants.VerrazzanoBinding: binding.Name, constants.VerrazzanoCluster: managedClusterName}
+	return map[string]string{constants.K8SAppLabel: constants.VerrazzanoGroup, constants.VerrazzanoBinding: binding.Name, constants.VerrazzanoCluster: managedClusterName, "istio-injection" : "enabled"}
 }
 
 // GetManagedLabelsNoBinding return labels for managed cluster with no binding.


### PR DESCRIPTION
Though the days of the resources in this namespace are apparently numbered, for the time being the logging namespace is labeled with the istio injection annotation to facilitate communication with other VZ resources.