### PR TITLE
JIRA:VZ-3948 pickup latest VMO in go.mod

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1537,4 +1537,4 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: 2e82b2524d344ca69c4ec3c77622df9b
+License file based on go.mod with md5 sum: 5a706f4b75ac5b8b219d21c5635a6d28

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -130,6 +130,7 @@ Copyright (C) 2020, Oracle and/or its affiliates.
 Copyright (c) 2020, Oracle and/or its affiliates.
 Copyright 2019 The Kubernetes Authors.
 Copyright (C) 2021, Oracle and/or its affiliates.
+Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 
 -------- Dependencies Summary
 github.com/verrazzano/verrazzano-monitoring-operator
@@ -1536,4 +1537,4 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: 0c9fd9136cb78c4f4e43d679487180d4
+License file based on go.mod with md5 sum: 2e82b2524d344ca69c4ec3c77622df9b

--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	github.com/verrazzano/pkg v0.0.2
-	github.com/verrazzano/verrazzano-monitoring-operator v0.0.0-20210506182921-9c8e9e80ff10
+	github.com/verrazzano/verrazzano-monitoring-operator v0.0.0-20211101174307-1998b282d4f9
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309 // indirect
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 // indirect
-	k8s.io/api v0.19.2
+	k8s.io/api v0.21.1
 	k8s.io/apiextensions-apiserver v0.19.2
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	github.com/verrazzano/pkg v0.0.2
-	github.com/verrazzano/verrazzano-monitoring-operator v0.0.0-20211101174307-1998b282d4f9
+	github.com/verrazzano/verrazzano-monitoring-operator v0.0.26
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309 // indirect

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,7 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
+github.com/go-resty/resty/v2 v2.6.0/go.mod h1:PwvJS6hvaPkjtjNg9ph+VrSD92bi5Zq73w/BIH7cC3Q=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -414,6 +415,8 @@ github.com/verrazzano/pkg v0.0.2 h1:Q80lpGaAswNPXkZZL/0THIa9PXvewi+c6xSSzWQyhG8=
 github.com/verrazzano/pkg v0.0.2/go.mod h1:l9utTv9KBQZlJI/HYnw2NQwisYTeHeHl82XOlCiZygM=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.0-20210506182921-9c8e9e80ff10 h1:g01cMunYjF5H8IhN065ayN1bZeMpOfC6CfeNpFVS1s0=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.0-20210506182921-9c8e9e80ff10/go.mod h1:2Vp7mw4gb/d4yHwZ6iF5ktsYjckmEjbM0TrMcoh7qf8=
+github.com/verrazzano/verrazzano-monitoring-operator v0.0.0-20211101174307-1998b282d4f9 h1:VcnQtHXAV8a+pTWvCx6Y4bUcrKfzTQJa4yYbwGE12rs=
+github.com/verrazzano/verrazzano-monitoring-operator v0.0.0-20211101174307-1998b282d4f9/go.mod h1:LhAarjsfEaFMH8HrOAFyTokjl3nssYLw9/ApkGfCWu4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -502,6 +505,7 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211020060615-d418f374d309 h1:A0lJIi+hcTR6aajJH4YqKWwohY4aW9RO7oRMcdv+HKI=
 golang.org/x/net v0.0.0-20211020060615-d418f374d309/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -554,6 +558,7 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 h1:5/PjkGUjvEU5Gl6BxmvKRPpqo2uNMv4rcHBMwzk/st8=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -417,6 +417,8 @@ github.com/verrazzano/verrazzano-monitoring-operator v0.0.0-20210506182921-9c8e9
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.0-20210506182921-9c8e9e80ff10/go.mod h1:2Vp7mw4gb/d4yHwZ6iF5ktsYjckmEjbM0TrMcoh7qf8=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.0-20211101174307-1998b282d4f9 h1:VcnQtHXAV8a+pTWvCx6Y4bUcrKfzTQJa4yYbwGE12rs=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.0-20211101174307-1998b282d4f9/go.mod h1:LhAarjsfEaFMH8HrOAFyTokjl3nssYLw9/ApkGfCWu4=
+github.com/verrazzano/verrazzano-monitoring-operator v0.0.26 h1:gquEWF318Yohd3Qmz74Ksr5pEhi4I5grTPkrwbMhzgg=
+github.com/verrazzano/verrazzano-monitoring-operator v0.0.26/go.mod h1:LhAarjsfEaFMH8HrOAFyTokjl3nssYLw9/ApkGfCWu4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
VMO has been updated to pickup k8s 0.19.2 and controller-runtime 0.6.2, so the VO had to be updated to pickup this new VMO (release as version v0.0.26)

VZ tests confirming these versions work:  https://build.verrazzano.io/job/verrazzano/job/jmaron%252FVZ-3948-testing/8/
Triggered tests (had to be re-run due to spurious issues in OCI DNS and one other suite): https://build.verrazzano.io/job/verrazzano-push-triggered-acceptance-tests/job/jmaron%252FVZ-3948-testing/5/